### PR TITLE
Fix nil pointer exception & Optimize exception tips

### DIFF
--- a/protocol/motanProtocol.go
+++ b/protocol/motanProtocol.go
@@ -83,7 +83,7 @@ var (
 	ErrStatus         = errors.New("message status not correct")
 	ErrMetadata       = errors.New("decode meta data fail")
 	ErrSerializeNum   = errors.New("message serialize number not correct")
-	ErrSerializeNil   = errors.New("message serialize is nil")
+	ErrSerializeNil   = errors.New("message serialize not found")
 	ErrSerializedData = errors.New("message serialized data not correct")
 )
 

--- a/server/motanserver.go
+++ b/server/motanserver.go
@@ -115,31 +115,28 @@ func (m *MotanServer) processReq(request *mpro.Message, conn net.Conn) {
 		var mres motan.Response
 		serialization := m.extFactory.GetSerialization("", request.Header.GetSerialize())
 		req, err := mpro.ConvertToRequest(request, serialization)
-
-		if ta, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
-			req.SetAttachment(motan.HostKey, ta.IP.String())
-		} else {
-			req.SetAttachment(motan.HostKey, getRemoteIP(conn.RemoteAddr().String()))
-		}
-
-		req.GetRPCContext(true).ExtFactory = m.extFactory
 		if err != nil {
 			vlog.Errorf("motan server convert to motan request fail. rid :%d, service: %s, method:%s,err:%s\n", request.Header.RequestID, request.Metadata[mpro.MPath], request.Metadata[mpro.MMethod], err.Error())
-			mres = motan.BuildExceptionResponse(request.Header.RequestID, &motan.Exception{ErrCode: 500, ErrMsg: "deserialize fail. method:" + request.Metadata[mpro.MMethod], ErrType: motan.ServiceException})
+			res = mpro.BuildExceptionResponse(request.Header.RequestID, mpro.ExceptionToJSON(&motan.Exception{ErrCode: 500, ErrMsg: "deserialize fail. err:" + err.Error() + " method:" + request.Metadata[mpro.MMethod], ErrType: motan.ServiceException}))
 		} else {
+			if ta, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+				req.SetAttachment(motan.HostKey, ta.IP.String())
+			} else {
+				req.SetAttachment(motan.HostKey, getRemoteIP(conn.RemoteAddr().String()))
+			}
 			req.GetRPCContext(true).ExtFactory = m.extFactory
 			mres = m.handler.Call(req)
-			//TOOD oneway
-		}
-		if mres != nil {
-			mres.GetRPCContext(true).Proxy = m.proxy
-			res, err = mpro.ConvertToResMessage(mres, serialization)
-		} else {
-			err = errors.New("handler call return nil")
-		}
+			//TODO oneway
+			if mres != nil {
+				mres.GetRPCContext(true).Proxy = m.proxy
+				res, err = mpro.ConvertToResMessage(mres, serialization)
+			} else {
+				err = errors.New("handler call return nil")
+			}
 
-		if err != nil {
-			res = mpro.BuildExceptionResponse(request.Header.RequestID, mpro.ExceptionToJSON(&motan.Exception{ErrCode: 500, ErrMsg: "convert to response fail.", ErrType: motan.ServiceException}))
+			if err != nil {
+				res = mpro.BuildExceptionResponse(request.Header.RequestID, mpro.ExceptionToJSON(&motan.Exception{ErrCode: 500, ErrMsg: "convert to response fail. err:" + err.Error(), ErrType: motan.ServiceException}))
+			}
 		}
 	}
 	resbuf := res.Encode()


### PR DESCRIPTION
Step:  
1. java client set the serialization as 'hession'，request go-server.

Result: go-server response nil pointer exception:
`E0504 15:19:58.694842     608 motanserver.go:106] Motanserver processReq error!  runtime error: invalid memory address or nil pointer dereference`

Reason: go-sever only supports simple serialization currently.