### PR TITLE
Add support for OpenTracing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - go get golang.org/x/tools/cmd/cover
     
 install:
-    - go get -d -v $(go list ./... | grep -v main)
+    - go get -d -v -t $(go list ./... | grep -v main)
 
 script:
     - go test -v $(go list ./... | grep -v main)

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,7 +1,6 @@
 package filter
 
 import (
-	"github.com/opentracing/opentracing-go"
 	motan "github.com/weibocom/motan-go/core"
 )
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -10,7 +10,7 @@ const (
 	Metrics        = "metrics"
 	CircuitBreaker = "circuitbreaker"
 	FailFast       = "failfast"
-	Tracing        = "tracing"
+	Trace          = "trace"
 )
 
 func RegistDefaultFilters(extFactory motan.ExtentionFactory) {
@@ -30,7 +30,7 @@ func RegistDefaultFilters(extFactory motan.ExtentionFactory) {
 		return &FailfastFilter{}
 	})
 
-	extFactory.RegistExtFilter(Tracing, func() motan.Filter {
+	extFactory.RegistExtFilter(Trace, func() motan.Filter {
 		return &TracingFilter{}
 	})
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,6 +1,9 @@
 package filter
 
-import motan "github.com/weibocom/motan-go/core"
+import (
+	"github.com/opentracing/opentracing-go"
+	motan "github.com/weibocom/motan-go/core"
+)
 
 // ext name
 const (
@@ -8,6 +11,7 @@ const (
 	Metrics        = "metrics"
 	CircuitBreaker = "circuitbreaker"
 	FailFast       = "failfast"
+	Tracing        = "tracing"
 )
 
 func RegistDefaultFilters(extFactory motan.ExtentionFactory) {
@@ -25,5 +29,9 @@ func RegistDefaultFilters(extFactory motan.ExtentionFactory) {
 
 	extFactory.RegistExtFilter(FailFast, func() motan.Filter {
 		return &FailfastFilter{}
+	})
+
+	extFactory.RegistExtFilter(Tracing, func() motan.Filter {
+		return &TracingFilter{}
 	})
 }

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -1,0 +1,160 @@
+package filter
+
+import (
+	"github.com/weibocom/motan-go/core"
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+);
+
+// TracingFilter用来拦截所有的RPC请求，包括接收的请求和发出的请求
+//
+//    1. 接收的请求，当前作为服务端，此时caller应该为core.Provider类型
+//    2. 发出的请求，当前作为客户端，此时caller应该为core.Endpoint类型
+//
+// 正常情况下，假设有一个调用链为
+//
+//               (1)                 (2)
+//    caller -----------> worker -----------> dependents
+//             [span1]             [span2]
+//
+// 此时span1为span2的parent。
+//
+// 那么增加agent之后调用边变成
+//
+//               (1)                (1)                 (2)                (2)
+//    caller -----------> agent -----------> worker -----------> agent -----------> dependents
+//             [span1]            [span1] <pass-thru> [span1]            [span2]
+//
+type TracingFilter struct {
+	next core.EndPointFilter
+}
+
+func (t *TracingFilter) SetNext(nextFilter core.EndPointFilter) {
+	t.next = nextFilter
+}
+
+func (t *TracingFilter) GetNext() core.EndPointFilter {
+	return t.next
+}
+
+func (cf *TracingFilter) Filter(caller core.Caller, request core.Request) core.Response {
+	if _, ok := caller.(core.Provider); ok {
+		return filterForProvider(caller.(core.Provider), request)
+	} else if _, ok := caller.(core.EndPoint); ok {
+		return filterForClient(caller.(core.EndPoint), request)
+	} else {
+		return caller.Call(request)
+	}
+}
+
+func filterForClient(caller core.EndPoint, request core.Request) core.Response {
+	sc, err := ot.GlobalTracer().Extract(ot.TextMap, AttachmentReader{attach: request})
+	var span ot.Span
+	if err == ot.ErrSpanContextNotFound {
+		// 如果请求中没有span信息，则创建一个根span
+		span = ot.StartSpan(spanName(&request), ext.SpanKindRPCClient)
+	} else {
+		// 如果请求中有span信息，则创建该span对应的一个子span
+		span = ot.StartSpan(spanName(&request), ot.ChildOf(sc), ext.SpanKindRPCClient)
+	}
+	defer span.Finish()
+
+	span.SetTag("ca", core.GetLocalIP())
+	span.SetTag("peer.ipv4", caller.GetURL().Host)
+	span.SetTag("peer.port", caller.GetURL().Port)
+
+	ot.GlobalTracer().Inject(span.Context(), ot.TextMap, AttachmentWriter{attach: request})
+
+	defer recoverFromPanic(&span)
+	response := caller.Call(request)
+	if response.GetException() != nil {
+		span.SetTag("error", true)
+		span.LogFields(log.Int("error.kind", response.GetException().ErrType))
+		span.LogFields(log.String("message", response.GetException().ErrMsg))
+	}
+	return response
+}
+
+func filterForProvider(caller core.Provider, request core.Request) core.Response {
+	sc, _ := ot.GlobalTracer().Extract(ot.TextMap, AttachmentReader{attach: request})
+	var span ot.Span
+	// 如果请求中没有span信息，则创建一个根span
+	// 如果请求中有span信息，则创建该span对应的一个子span
+	span = ot.StartSpan(spanName(&request), ext.RPCServerOption(sc))
+	defer span.Finish()
+
+	span.SetTag("ca", core.GetLocalIP())
+
+	ot.GlobalTracer().Inject(span.Context(), ot.TextMap, AttachmentWriter{attach: request})
+
+	defer recoverFromPanic(&span)
+	response := caller.Call(request)
+	if response.GetException() != nil {
+		span.SetTag("error", true)
+		span.LogFields(log.Int("error.kind", response.GetException().ErrType))
+		span.LogFields(log.String("message", response.GetException().ErrMsg))
+	}
+	return response
+}
+
+func recoverFromPanic(span *ot.Span) {
+	if r := recover(); r != nil {
+		(*span).SetTag("error", true)
+		(*span).LogFields(log.Int("error.kind", core.ServiceException))
+		(*span).LogFields(log.Object("message", r))
+		panic(r)
+	}
+}
+
+func spanName(request *core.Request) string {
+	return (*request).GetServiceName() + "." + (*request).GetMethod()
+}
+
+func (*TracingFilter) GetName() string {
+	return "TracingFilter"
+}
+
+func (t *TracingFilter) NewFilter(url *core.URL) core.Filter {
+	return t
+}
+
+func (t *TracingFilter) HasNext() bool {
+	return t.next != nil
+}
+
+func (*TracingFilter) GetIndex() int {
+	return 2
+}
+
+func (*TracingFilter) GetType() int32 {
+	return core.EndPointFilterType
+}
+
+type AttachmentReader struct {
+	attach core.Attachment
+}
+
+func (a *AttachmentReader) ForeachKey(handler func(key, val string) error) error {
+	att := a.attach.GetAttachments()
+	if att == nil {
+		return nil
+	}
+
+	for k, v := range att {
+		err := handler(k, v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type AttachmentWriter struct {
+	attach core.Attachment
+}
+
+func (a *AttachmentWriter) Set(key, val string) {
+	a.attach.SetAttachment(key, val)
+}

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -101,6 +101,7 @@ func (cf *TracingFilter) filterForClient(caller core.EndPoint, request core.Requ
 	span.SetTag("ca", core.GetLocalIP())
 	span.SetTag("peer.ipv4", caller.GetURL().Host)
 	span.SetTag("peer.port", caller.GetURL().Port)
+	span.SetTag("service.type", "motan")
 
 	ot.GlobalTracer().Inject(span.Context(), ot.TextMap, AttachmentWriter{attach: request})
 
@@ -126,6 +127,8 @@ func (cf *TracingFilter) filterForProvider(caller core.Provider, request core.Re
 	defer span.Finish()
 
 	span.SetTag("ca", core.GetLocalIP())
+	remoteHost := request.GetAttachment(core.HostKey)
+	span.SetTag("peer.ipv4", remoteHost)
 
 	ot.GlobalTracer().Inject(span.Context(), ot.TextMap, AttachmentWriter{attach: request})
 
@@ -135,6 +138,7 @@ func (cf *TracingFilter) filterForProvider(caller core.Provider, request core.Re
 
 	if response.GetException() != nil {
 		span.SetTag("error", true)
+		span.SetTag("service.type", "motan")
 		span.LogFields(log.Int("error.kind", response.GetException().ErrType))
 		span.LogFields(log.String("message", response.GetException().ErrMsg))
 	}

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -86,7 +86,7 @@ func (cf *TracingFilter) filterForClient(caller core.EndPoint, request core.Requ
 
 	ot.GlobalTracer().Inject(span.Context(), ot.TextMap, AttachmentWriter{attach: request})
 
-	defer recoverFromPanic(&span)
+	defer handleIfPanic(span)
 
 	var response = callNext(cf, caller, request)
 
@@ -110,7 +110,7 @@ func (cf *TracingFilter) filterForProvider(caller core.Provider, request core.Re
 
 	ot.GlobalTracer().Inject(span.Context(), ot.TextMap, AttachmentWriter{attach: request})
 
-	defer recoverFromPanic(&span)
+	defer handleIfPanic(span)
 
 	response := callNext(cf, caller, request)
 
@@ -132,11 +132,11 @@ func callNext(cf *TracingFilter, caller core.Caller, request core.Request) core.
 	return response
 }
 
-func recoverFromPanic(span *ot.Span) {
+func handleIfPanic(span ot.Span) {
 	if r := recover(); r != nil {
-		(*span).SetTag("error", true)
-		(*span).LogFields(log.Int("error.kind", core.ServiceException))
-		(*span).LogFields(log.Object("message", r))
+		span.SetTag("error", true)
+		span.LogFields(log.Int("error.kind", core.ServiceException))
+		span.LogFields(log.Object("message", r))
 		panic(r)
 	}
 }

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -26,7 +26,7 @@ type CallData struct {
 // If this function is set, when a call is made, the function will be called
 var CustomRecordingFunc func(span *ot.Span, data CallData)
 
-// TracingFilter is designed to support OpenTracing, thus we make use of
+// TracingFilter is designed to support OpenTracing, so that we can make use of
 // tracing capability many tracing systems (such as zipkin, etc.)
 //
 // As described by OpenTracing, for a single call from client to server, both sides will start a span,

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -119,7 +119,8 @@ func (cf *TracingFilter) filterForClient(caller core.EndPoint, request core.Requ
 
 	span.SetTag(string(ext.PeerHostIPv4), caller.GetURL().Host)
 	span.SetTag(string(ext.PeerPort), caller.GetURL().Port)
-	span.SetTag(string(ext.PeerService), "motan")
+	span.SetTag("service.type", "motan")
+	span.SetTag("service.group", caller.GetURL().Group)
 
 	ot.GlobalTracer().Inject(span.Context(), ot.TextMap, AttachmentWriter{attach: request})
 
@@ -156,8 +157,11 @@ func (cf *TracingFilter) filterForProvider(caller core.Provider, request core.Re
 	span = ot.StartSpan(spanName(&request), ext.RPCServerOption(sc))
 	defer span.Finish()
 
-	remoteHost := request.GetAttachment(core.HostKey)
-	span.SetTag(string(ext.PeerHostIPv4), remoteHost)
+	if remoteHost := request.GetAttachment(core.HostKey); remoteHost != "" {
+		span.SetTag(string(ext.PeerHostIPv4), remoteHost)
+	}
+	span.SetTag("service.type", "motan")
+	span.SetTag("service.group", caller.GetURL().Group)
 
 	ot.GlobalTracer().Inject(span.Context(), ot.TextMap, AttachmentWriter{attach: request})
 

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -156,7 +156,6 @@ func (cf *TracingFilter) filterForProvider(caller core.Provider, request core.Re
 	span = ot.StartSpan(spanName(&request), ext.RPCServerOption(sc))
 	defer span.Finish()
 
-	span.SetTag("ca", core.GetLocalIP())
 	remoteHost := request.GetAttachment(core.HostKey)
 	span.SetTag(string(ext.PeerHostIPv4), remoteHost)
 

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -24,7 +24,7 @@ type CallData struct {
 }
 
 // If this function is set, when a call is made, the function will be called
-var CustomRecordingFunc func(span *ot.Span, data CallData)
+var CustomTraceRecordingFunc func(span *ot.Span, data CallData)
 
 // TracingFilter is designed to support OpenTracing, so that we can make use of
 // tracing capability many tracing systems (such as zipkin, etc.)
@@ -128,8 +128,8 @@ func (cf *TracingFilter) filterForClient(caller core.EndPoint, request core.Requ
 
 	var response = callNext(cf, caller, request)
 
-	if CustomRecordingFunc != nil {
-		defer CustomRecordingFunc(&span, CallData{Caller: caller, Request: request, Response: response, Error: nil, Direction: OUT_BOUND_CALL})
+	if CustomTraceRecordingFunc != nil {
+		defer CustomTraceRecordingFunc(&span, CallData{Caller: caller, Request: request, Response: response, Error: nil, Direction: OUT_BOUND_CALL})
 	}
 
 	if ex := response.GetException(); ex != nil {
@@ -161,8 +161,8 @@ func (cf *TracingFilter) filterForProvider(caller core.Provider, request core.Re
 	defer handleIfPanic(span, caller, request, IN_BOUND_CALL)
 
 	response := callNext(cf, caller, request)
-	if CustomRecordingFunc != nil {
-		defer CustomRecordingFunc(&span, CallData{Caller: caller, Request: request, Response: response, Error: nil, Direction: IN_BOUND_CALL})
+	if CustomTraceRecordingFunc != nil {
+		defer CustomTraceRecordingFunc(&span, CallData{Caller: caller, Request: request, Response: response, Error: nil, Direction: IN_BOUND_CALL})
 	}
 
 	if ex := response.GetException(); ex != nil {
@@ -179,8 +179,8 @@ func handleIfPanic(span ot.Span, caller core.Caller, request core.Request, direc
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Int("error.kind", core.ServiceException))
 		span.LogFields(log.Object("error.object", r))
-		if CustomRecordingFunc != nil {
-			CustomRecordingFunc(&span, CallData{Caller: caller, Request: request, Response: nil, Error: r, Direction: direction})
+		if CustomTraceRecordingFunc != nil {
+			CustomTraceRecordingFunc(&span, CallData{Caller: caller, Request: request, Response: nil, Error: r, Direction: direction})
 		}
 		panic(r)
 	}

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -69,7 +69,7 @@ func (cf *TracingFilter) Filter(caller core.Caller, request core.Request) core.R
 }
 
 func (cf *TracingFilter) filterForClient(caller core.EndPoint, request core.Request) core.Response {
-	sc, err := ot.GlobalTracer().Extract(ot.TextMap, &AttachmentReader{attach: request})
+	sc, err := ot.GlobalTracer().Extract(ot.TextMap, AttachmentReader{attach: request})
 	var span ot.Span
 	if err == ot.ErrSpanContextNotFound {
 		// 如果请求中没有span信息，则创建一个根span
@@ -150,7 +150,7 @@ func (*TracingFilter) GetName() string {
 }
 
 func (t *TracingFilter) NewFilter(url *core.URL) core.Filter {
-	return t
+	return &TracingFilter{}
 }
 
 func (t *TracingFilter) HasNext() bool {
@@ -165,6 +165,8 @@ func (*TracingFilter) GetType() int32 {
 	return core.EndPointFilterType
 }
 
+// AttachmentReader is used to read the Attachment.
+// use value type, to decrease the number of escaped variables
 type AttachmentReader struct {
 	attach core.Attachment
 }

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -1,10 +1,10 @@
 package filter
 
 import (
-	"github.com/weibocom/motan-go/core"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
+	"github.com/weibocom/motan-go/core"
 );
 
 // TracingFilter用来拦截所有的RPC请求，包括接收的请求和发出的请求

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -126,8 +126,6 @@ func callNext(cf *TracingFilter, caller core.Caller, request core.Request) core.
 	var response core.Response
 	if next := cf.GetNext(); next != nil {
 		response = next.Filter(caller, request)
-	} else {
-		response = caller.Call(request)
 	}
 	return response
 }

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -7,11 +7,6 @@ import (
 	"github.com/weibocom/motan-go/core"
 );
 
-const (
-	tracingWithAgent = "x-tracing-by-agent"
-	yes              = "true"
-)
-
 // TracingFilter用来拦截所有的RPC请求，包括接收的请求和发出的请求
 //
 //    1. 接收的请求，当前作为服务端，此时caller应该为core.Provider类型

--- a/filter/tracing.go
+++ b/filter/tracing.go
@@ -69,7 +69,7 @@ func (cf *TracingFilter) Filter(caller core.Caller, request core.Request) core.R
 }
 
 func (cf *TracingFilter) filterForClient(caller core.EndPoint, request core.Request) core.Response {
-	sc, err := ot.GlobalTracer().Extract(ot.TextMap, AttachmentReader{attach: request})
+	sc, err := ot.GlobalTracer().Extract(ot.TextMap, &AttachmentReader{attach: request})
 	var span ot.Span
 	if err == ot.ErrSpanContextNotFound {
 		// 如果请求中没有span信息，则创建一个根span
@@ -169,7 +169,7 @@ type AttachmentReader struct {
 	attach core.Attachment
 }
 
-func (a *AttachmentReader) ForeachKey(handler func(key, val string) error) error {
+func (a AttachmentReader) ForeachKey(handler func(key, val string) error) error {
 	att := a.attach.GetAttachments()
 	if att == nil {
 		return nil
@@ -189,6 +189,6 @@ type AttachmentWriter struct {
 	attach core.Attachment
 }
 
-func (a *AttachmentWriter) Set(key, val string) {
+func (a AttachmentWriter) Set(key, val string) {
 	a.attach.SetAttachment(key, val)
 }

--- a/filter/tracing_test.go
+++ b/filter/tracing_test.go
@@ -1,0 +1,2 @@
+package filter
+

--- a/filter/tracing_test.go
+++ b/filter/tracing_test.go
@@ -26,7 +26,9 @@ func TestAttachmentReader_ForeachKey(t *testing.T) {
 
 func TestAttachmentWriter_Set(t *testing.T) {
 	cases :=
-		[]entry{
+		[]struct{
+			K, V string
+		} {
 			{"a", "b"},
 			{"c", "d"},
 			{"a", "h"},
@@ -121,10 +123,6 @@ func (r *Referrer) SetSerialization(s core.Serialization) {
 
 func (r *Referrer) SetProxy(proxy bool) {
 	// DO NOTHING
-}
-
-type entry struct {
-	K, V string
 }
 
 type TestAttachment map[string]string

--- a/filter/tracing_test.go
+++ b/filter/tracing_test.go
@@ -1,10 +1,12 @@
 package filter
 
 import (
+	"fmt"
 	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/opentracing/opentracing-go/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/weibocom/motan-go/core"
+	"math/rand"
 	"testing"
 )
 
@@ -26,9 +28,9 @@ func TestAttachmentReader_ForeachKey(t *testing.T) {
 
 func TestAttachmentWriter_Set(t *testing.T) {
 	cases :=
-		[]struct{
+		[]struct {
 			K, V string
-		} {
+		}{
 			{"a", "b"},
 			{"c", "d"},
 			{"a", "h"},
@@ -54,10 +56,14 @@ func TestAttachmentWriter_Set(t *testing.T) {
 //    * caller
 //
 // But the infrastructure is not enough, So disable it temporary
-func testTracingFilter_Filter(t *testing.T) {
+func TestTracingFilter_Filter(t *testing.T) {
 	req := core.MotanRequest{
-		RequestID:   1,
-		Attachment:  make(map[string]string),
+		RequestID: 1,
+		Attachment: map[string]string{
+			"tid": "1",
+			"id":  "2",
+			"pid": "3",
+		},
 		Method:      "foo",
 		ServiceName: "FooService",
 		Arguments:   []interface{}{},
@@ -65,20 +71,269 @@ func testTracingFilter_Filter(t *testing.T) {
 		RPCContext:  &core.RPCContext{},
 	}
 
-	referrer := Referrer{
-		name: "foo referrer",
-		call: func(request core.Request) core.Response {
-			return nil
-		},
-		url: core.URL{Host: "1.2.3.4", Port: 8065, Group: "test-group"},
+	filterFunc := func(caller core.Caller, request core.Request) core.Response {
+		assert.Equal(t, request.GetAttachment("tid"), "1")
+		assert.Equal(t, request.GetAttachment("pid"), "2")
+		return &MockResponse{}
 	}
 
-	tracer := mocktracer.New()
+	referrer := Referrer{
+		name: "foo referrer",
+		call: filterFunc,
+		url:  core.URL{Host: "1.2.3.4", Port: 8065, Group: "test-group"},
+	}
+
+	tracer := &MockTracer{}
 	opentracing.SetGlobalTracer(tracer)
 
-	filter := &TracingFilter{}
+	mockFilter := MockFilter{
+		filter: filterFunc,
+	}
+	filter := &TracingFilter{next: &mockFilter}
 	filter.Filter(&referrer, &req)
 
+}
+
+type SpanContext struct {
+	traceId, id, parentId string
+}
+
+func (c SpanContext) isParentFor(ctx *SpanContext) bool {
+	if ctx == nil {
+		return false
+	} else if ctx.traceId != c.traceId {
+		return false
+	} else if ctx.parentId != c.id {
+		return false
+	} else {
+		return true
+	}
+}
+
+func (c *SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
+	handler("tid", c.traceId)
+	handler("id", c.id)
+	handler("pid", c.parentId)
+}
+
+type MockSpan struct {
+	name    string
+	context SpanContext
+	tags    map[string]interface{}
+	logs    map[string]log.Field
+	tracer  *MockTracer
+	kind    string
+}
+
+func (*MockSpan) Finish() {
+
+}
+
+func (*MockSpan) FinishWithOptions(opts opentracing.FinishOptions) {
+
+}
+
+func (s *MockSpan) Context() opentracing.SpanContext {
+	return &s.context
+}
+
+func (s *MockSpan) SetOperationName(operationName string) opentracing.Span {
+	s.name = operationName
+	return s
+}
+
+func (s *MockSpan) SetTag(key string, value interface{}) opentracing.Span {
+	if s.tags == nil {
+		s.tags = make(map[string]interface{})
+	}
+	s.tags[key] = value
+	return s
+}
+
+func (s *MockSpan) LogFields(fields ...log.Field) {
+	ensureLogField(s)
+	for _, f := range fields {
+		s.logs[f.Key()] = f
+	}
+}
+
+func ensureLogField(s *MockSpan) {
+	if s.logs == nil {
+		s.logs = make(map[string]log.Field)
+	}
+}
+
+func (s *MockSpan) LogKV(alternatingKeyValues ...interface{}) {
+	ensureLogField(s)
+
+}
+
+func (s *MockSpan) SetBaggageItem(restrictedKey, value string) opentracing.Span {
+	return s
+}
+
+func (s *MockSpan) BaggageItem(restrictedKey string) string {
+	panic("implement me")
+}
+
+func (s *MockSpan) Tracer() opentracing.Tracer {
+	return s.tracer
+}
+
+func (*MockSpan) LogEvent(event string) {
+	panic("implement me")
+}
+
+func (*MockSpan) LogEventWithPayload(event string, payload interface{}) {
+	panic("implement me")
+}
+
+func (*MockSpan) Log(data opentracing.LogData) {
+	panic("implement me")
+}
+
+type MockTracer struct {
+}
+
+func (t *MockTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	options := opentracing.StartSpanOptions{}
+	for _, opt := range opts {
+		opt.Apply(&options)
+	}
+
+	id := fmt.Sprintf("%x", rand.Uint64())
+	var ctxt *SpanContext
+	if options.References != nil && len(options.References) > 0 {
+		ref := options.References[0].ReferencedContext
+		if c, ok := ref.(*SpanContext); ok {
+			ctxt = &SpanContext{traceId: c.traceId, parentId: c.id, id: id}
+		}
+	}
+	if ctxt == nil {
+		ctxt = &SpanContext{traceId: id, id: id}
+	}
+
+	return &MockSpan{context: *ctxt, name: operationName, tracer: t, tags: options.Tags}
+}
+
+func (*MockTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	switch format {
+	case opentracing.TextMap:
+		if w, ok := carrier.(opentracing.TextMapWriter); ok {
+			sm.ForeachBaggageItem(func(k, v string) bool {
+				w.Set(k, v)
+				return true
+			})
+		}
+	case opentracing.Binary:
+	case opentracing.HTTPHeaders:
+	}
+	return nil
+}
+
+func (*MockTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	switch format {
+	case opentracing.TextMap:
+		if r, ok := (carrier).(opentracing.TextMapReader); ok {
+			var id, traceId, parentId string
+			r.ForeachKey(func(key, val string) error {
+				switch key {
+				case "tid":
+					traceId = val
+				case "id":
+					id = val
+				case "pid":
+					parentId = val
+				}
+				return nil
+			})
+			return &SpanContext{traceId: traceId, id: id, parentId: parentId}, nil
+		}
+	}
+	return nil, nil
+}
+
+type MockResponse struct {
+}
+
+func (*MockResponse) GetAttachment(key string) string {
+	panic("implement me")
+}
+
+func (*MockResponse) GetAttachments() map[string]string {
+	panic("implement me")
+}
+
+func (*MockResponse) GetException() *core.Exception {
+	return nil
+}
+
+func (*MockResponse) GetProcessTime() int64 {
+	panic("implement me")
+}
+
+func (*MockResponse) GetRPCContext(canCreate bool) *core.RPCContext {
+	panic("implement me")
+}
+
+func (*MockResponse) GetRequestID() uint64 {
+	panic("implement me")
+}
+
+func (*MockResponse) GetValue() interface{} {
+	panic("implement me")
+}
+
+func (*MockResponse) ProcessDeserializable(toType interface{}) error {
+	panic("implement me")
+}
+
+func (*MockResponse) SetAttachment(key string, value string) {
+	panic("implement me")
+}
+
+func (*MockResponse) SetProcessTime(time int64) {
+	panic("implement me")
+}
+
+type MockFilter struct {
+	filter func(caller core.Caller, request core.Request) core.Response
+}
+
+func (*MockFilter) SetNext(nextFilter core.EndPointFilter) {
+	panic("implement me")
+}
+
+func (*MockFilter) GetNext() core.EndPointFilter {
+	panic("implement me")
+}
+
+func (f *MockFilter) Filter(caller core.Caller, request core.Request) core.Response {
+	if f.filter != nil {
+		return f.filter(caller, request)
+	} else {
+		panic("mock func 'filter' not set")
+	}
+}
+
+func (*MockFilter) GetName() string {
+	panic("implement me")
+}
+
+func (*MockFilter) NewFilter(url *core.URL) core.Filter {
+	panic("implement me")
+}
+
+func (*MockFilter) HasNext() bool {
+	panic("implement me")
+}
+
+func (*MockFilter) GetIndex() int {
+	panic("implement me")
+}
+
+func (*MockFilter) GetType() int32 {
+	panic("implement me")
 }
 
 type Referrer struct {
@@ -86,7 +341,7 @@ type Referrer struct {
 	url       core.URL
 	available bool
 
-	call func(request core.Request) core.Response
+	call func(caller core.Caller, request core.Request) core.Response
 }
 
 func (r *Referrer) GetName() string {
@@ -107,9 +362,9 @@ func (r *Referrer) IsAvailable() bool {
 
 func (r *Referrer) Call(request core.Request) core.Response {
 	if r.call != nil {
-		return r.call(request)
+		return r.call(nil, request)
 	} else {
-		return nil
+		panic("call method not found")
 	}
 }
 

--- a/filter/tracing_test.go
+++ b/filter/tracing_test.go
@@ -1,2 +1,142 @@
 package filter
 
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/stretchr/testify/assert"
+	"github.com/weibocom/motan-go/core"
+	"testing"
+)
+
+func TestAttachmentReader_ForeachKey(t *testing.T) {
+	att := TestAttachment{}
+	att.SetAttachment("k1", "v1")
+	att.SetAttachment("k2", "v2")
+
+	r := AttachmentReader{attach: &att}
+
+	n := 0
+	r.ForeachKey(func(key, val string) error {
+		defer func() { n++ }()
+		assert.Equal(t, att[key], val)
+		return nil
+	})
+	assert.Equal(t, len(att), n)
+}
+
+func TestAttachmentWriter_Set(t *testing.T) {
+	cases :=
+		[]entry{
+			{"a", "b"},
+			{"c", "d"},
+			{"a", "h"},
+			{"e", "f"},
+		}
+
+	att := TestAttachment{}
+
+	w := AttachmentWriter{attach: &att}
+
+	for _, e := range cases {
+		w.Set(e.K, e.V)
+		assert.Equal(t, e.V, att[e.K])
+	}
+}
+
+// This test case needs to mock a lot of things:
+//
+//
+//    * Tracer
+//    * Request
+//	  * Response
+//    * caller
+//
+// But the infrastructure is not enough, So disable it temporary
+func testTracingFilter_Filter(t *testing.T) {
+	req := core.MotanRequest{
+		RequestID:   1,
+		Attachment:  make(map[string]string),
+		Method:      "foo",
+		ServiceName: "FooService",
+		Arguments:   []interface{}{},
+		MethodDesc:  "FooService.foo()",
+		RPCContext:  &core.RPCContext{},
+	}
+
+	referrer := Referrer{
+		name: "foo referrer",
+		call: func(request core.Request) core.Response {
+			return nil
+		},
+		url: core.URL{Host: "1.2.3.4", Port: 8065, Group: "test-group"},
+	}
+
+	tracer := mocktracer.New()
+	opentracing.SetGlobalTracer(tracer)
+
+	filter := &TracingFilter{}
+	filter.Filter(&referrer, &req)
+
+}
+
+type Referrer struct {
+	name      string
+	url       core.URL
+	available bool
+
+	call func(request core.Request) core.Response
+}
+
+func (r *Referrer) GetName() string {
+	return r.name
+}
+
+func (r *Referrer) GetURL() *core.URL {
+	return &r.url
+}
+
+func (r *Referrer) SetURL(url *core.URL) {
+	r.url = *url
+}
+
+func (r *Referrer) IsAvailable() bool {
+	return r.available
+}
+
+func (r *Referrer) Call(request core.Request) core.Response {
+	if r.call != nil {
+		return r.call(request)
+	} else {
+		return nil
+	}
+}
+
+func (r *Referrer) Destroy() {
+	r.available = false
+}
+
+func (r *Referrer) SetSerialization(s core.Serialization) {
+	// DO NOTHING
+}
+
+func (r *Referrer) SetProxy(proxy bool) {
+	// DO NOTHING
+}
+
+type entry struct {
+	K, V string
+}
+
+type TestAttachment map[string]string
+
+func (t *TestAttachment) GetAttachments() map[string]string {
+	return *t
+}
+
+func (t *TestAttachment) GetAttachment(key string) string {
+	return (*t)[key]
+}
+
+func (t *TestAttachment) SetAttachment(key string, value string) {
+	(*t)[key] = value
+}

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,3 +29,7 @@ import:
   subpackages:
   - metadata
 - package: gopkg.in/yaml.v2
+- package: github.com/opentracing/opentracing-go
+  subpackages:
+  - ext
+  - log

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,3 +33,6 @@ import:
   subpackages:
   - ext
   - log
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert


### PR DESCRIPTION
This PR will add [OpenTracing](http://opentracing.io) support to motan-go, and then we can collect the trace data to any compatible trace systems, such as [zipkin](https://zipkin.io). 

## What we should do if we wish to take use of this capability

1. Change configuration, add `trace` filter

  ```yaml
...
motan-basicService:
  example_basic_service:
    group: motan-go-example
    protocol: motan2
    registry: "direct-registry"
    filter: "accessLog,trace" # add 'trace' filter here
    serialization: simple
    nodeType: server
...
```

2. Set wanted Tracer

  ```go
tracer, _ := zipkintracer.NewTracer(recorder, zipkintracer.WithLogger(logger))
opentracing.SetGlobalTracer(tracer)
```

for tracers, please referer to [OpenTracing [Github]](https://github.com/opentracing/opentracing-go)

3. [Optional] Set custom recording function

  ```go
filter.TraceRecordingFunc = func(span opentracing.Span, data *filter.CallData) {
	// Do default recording
	filter.DefaultTraceRecordingFunc(span, data)
	// Do more recording
	span.SetTag("ca", motancore.LocalIP)
}
```

If not set, the `filter.DefaultTraceRecordingFunc(span opentracing.Span, data *filter.CallData)` is used directly, recording following information:

* `service.type`
* `service.group`
* `peer.host`
* `peer.port`
* `error`
