### PR TITLE
fix: application config priority

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -243,7 +243,16 @@ type agentMessageHandler struct {
 
 func (a *agentMessageHandler) Call(request motan.Request) (res motan.Response) {
 	if request.GetAttachment(mpro.MSource) == "" {
-		application := a.agent.agentURL.GetParam(motan.ApplicationKey, "")
+		application := ""
+		referName := request.GetServiceName()
+		for referID, referURL := range a.agent.Context.RefersURLs {
+			if referURL.Path == referName {
+				application = a.agent.Context.RefersURLs[referID].GetParam(motan.ApplicationKey, "")
+			}
+		}
+		if application == "" {
+			application = a.agent.agentURL.GetParam(motan.ApplicationKey, "")
+		}
 		request.SetAttachment(mpro.MSource, application)
 	}
 	version := "0.1"

--- a/agent.go
+++ b/agent.go
@@ -242,25 +242,19 @@ type agentMessageHandler struct {
 }
 
 func (a *agentMessageHandler) Call(request motan.Request) (res motan.Response) {
-	if request.GetAttachment(mpro.MSource) == "" {
-		application := ""
-		referName := request.GetServiceName()
-		for referID, referURL := range a.agent.Context.RefersURLs {
-			if referURL.Path == referName {
-				application = a.agent.Context.RefersURLs[referID].GetParam(motan.ApplicationKey, "")
-			}
-		}
-		if application == "" {
-			application = a.agent.agentURL.GetParam(motan.ApplicationKey, "")
-		}
-		request.SetAttachment(mpro.MSource, application)
-	}
 	version := "0.1"
 	if request.GetAttachment(mpro.MVersion) != "" {
 		version = request.GetAttachment(mpro.MVersion)
 	}
 	ck := getClusterKey(request.GetAttachment(mpro.MGroup), version, request.GetAttachment(mpro.MProxyProtocol), request.GetAttachment(mpro.MPath))
 	if motanCluster := a.agent.clustermap[ck]; motanCluster != nil {
+		if request.GetAttachment(mpro.MSource) == "" {
+			application := motanCluster.GetURL().GetParam(motan.ApplicationKey, "")
+			if application == "" {
+				application = a.agent.agentURL.GetParam(motan.ApplicationKey, "")
+			}
+			request.SetAttachment(mpro.MSource, application)
+		}
 		res = motanCluster.Call(request)
 		if res == nil {
 			vlog.Warningf("motanCluster Call return nil. cluster:%s\n", ck)

--- a/client.go
+++ b/client.go
@@ -75,20 +75,15 @@ func (c *Client) BaseGo(req motan.Request, reply interface{}, done chan *motan.A
 func (c *Client) BuildRequest(method string, args []interface{}) motan.Request {
 	req := &motan.MotanRequest{Method: method, ServiceName: c.url.Path, Arguments: args, Attachment: motan.NewStringMap(motan.DefaultAttachmentSize)}
 	version := c.url.GetParam(motan.VersionKey, "")
-	if version != "" {
-		req.SetAttachment(mpro.MVersion, version)
-	}
+	req.SetAttachment(mpro.MVersion, version)
 	module := c.url.GetParam(motan.ModuleKey, "")
-	if module != "" {
-		req.SetAttachment(mpro.MModule, module)
-	}
+	req.SetAttachment(mpro.MModule, module)
 	application := c.url.GetParam(motan.ApplicationKey, "")
 	if application == "" {
 		application = c.cluster.Context.ClientURL.GetParam(motan.ApplicationKey, "")
 	}
 	req.SetAttachment(mpro.MSource, application)
 	req.SetAttachment(mpro.MGroup, c.url.Group)
-
 	return req
 }
 

--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sync"
 
-	cluster "github.com/weibocom/motan-go/cluster"
+	"github.com/weibocom/motan-go/cluster"
 	motan "github.com/weibocom/motan-go/core"
 	mpro "github.com/weibocom/motan-go/protocol"
 )
@@ -83,9 +83,10 @@ func (c *Client) BuildRequest(method string, args []interface{}) motan.Request {
 		req.SetAttachment(mpro.MModule, module)
 	}
 	application := c.url.GetParam(motan.ApplicationKey, "")
-	if application != "" {
-		req.SetAttachment(mpro.MSource, application)
+	if application == "" {
+		application = c.cluster.Context.ClientURL.GetParam(motan.ApplicationKey, "")
 	}
+	req.SetAttachment(mpro.MSource, application)
 	req.SetAttachment(mpro.MGroup, c.url.Group)
 
 	return req

--- a/core/globalContext.go
+++ b/core/globalContext.go
@@ -47,7 +47,7 @@ type Context struct {
 	Config           *cfg.Config
 	RegistryURLs     map[string]*URL
 	RefersURLs       map[string]*URL
-	BasicRefers      map[string]*URL
+	BasicReferURLs   map[string]*URL
 	ServiceURLs      map[string]*URL
 	BasicServiceURLs map[string]*URL
 	AgentURL         *URL
@@ -118,7 +118,7 @@ func confToURL(urlInfo map[interface{}]interface{}) *URL {
 func (c *Context) Initialize() {
 	c.RegistryURLs = make(map[string]*URL)
 	c.RefersURLs = make(map[string]*URL)
-	c.BasicRefers = make(map[string]*URL)
+	c.BasicReferURLs = make(map[string]*URL)
 	c.ServiceURLs = make(map[string]*URL)
 	c.BasicServiceURLs = make(map[string]*URL)
 	if c.ConfigFile == "" { // use flag as default config file name
@@ -277,7 +277,7 @@ func (c *Context) basicConfToURLs(section string) map[string]*URL {
 		basicURLs = c.BasicServiceURLs
 		basicKey = basicServiceKey
 	} else if section == refersSection {
-		basicURLs = c.BasicRefers
+		basicURLs = c.BasicReferURLs
 		basicKey = basicReferKey
 	}
 	for key, url := range urls {
@@ -319,7 +319,7 @@ func (c *Context) parseRefers() {
 }
 
 func (c *Context) parseBasicRefers() {
-	c.BasicRefers = c.confToURLs(basicRefersSection)
+	c.BasicReferURLs = c.confToURLs(basicRefersSection)
 }
 
 func (c *Context) parseServices() {


### PR DESCRIPTION
- Priority：client's `ReferURL["application"]` > `ClientURL["application"]` > agent's `ReferURL["application"] `> `AgentURL["application"]`;
- Only when the above four values are empty, do not set the `application` parameter;
- The `application` parameter is in `request.Attachment.innerMap["M_s"]`.