### PR TITLE
Refactor ZkRegistry & Add a utility method

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -125,3 +125,27 @@ func HandlePanic(f func()) {
 		}
 	}
 }
+
+// TrimSplit slices s into all substrings separated by sep and
+// returns a slice of the substrings between those separators,
+// specially trim all substrings.
+func TrimSplit(s string, sep string) []string {
+	n := strings.Count(s, sep) + 1
+	a := make([]string, n)
+	i := 0
+	if sep == "" {
+		return strings.Split(s, sep)
+	}
+	for {
+		m := strings.Index(s, sep)
+		if m < 0 {
+			s = strings.TrimSpace(s)
+			break
+		}
+		a[i] = strings.TrimSpace(s[:m])
+		i++
+		s = s[m+len(sep):]
+	}
+	a[i] = s
+	return a[:i+1]
+}

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseExportString(t *testing.T) {
@@ -74,4 +75,28 @@ func TestHandlePanic(t *testing.T) {
 		b = true
 	})
 	panic("test panic")
+}
+
+func TestSplitTrim(t *testing.T) {
+	type SplitTest struct {
+		str    string
+		sep    string
+		expect []string
+	}
+	space := "\t\v\r\f\n\u0085\u00a0\u2000\u3000"
+	var splitList = []SplitTest{
+		{"", "", []string{}},
+		{"abcd", "", []string{"a", "b", "c", "d"}},
+		{"☺☻☹", "", []string{"☺", "☻", "☹"}},
+		{"abcd", "a", []string{"", "bcd"}},
+		{"abcd", "z", []string{"abcd"}},
+		{space + "1....2....3....4" + space, "...", []string{"1", ".2", ".3", ".4"}},
+		{"☺☻☹", "☹", []string{"☺☻", ""}},
+		{"1\t " + space + "\n2\t", " ", []string{"1", "2"}},
+		{"fd  , fds,  ,df\n, \v\ff ds ,,fd s , fds ,", ",", []string{"fd", "fds", "", "df", "f ds", "", "fd s", "fds", ""}},
+	}
+	for _, tt := range splitList {
+		ret := TrimSplit(tt.str, tt.sep)
+		assert.Equal(t, tt.expect, ret)
+	}
 }

--- a/ha/failoverHA.go
+++ b/ha/failoverHA.go
@@ -40,7 +40,7 @@ func (f *FailOverHA) Call(request motan.Request, loadBalance motan.LoadBalance) 
 		lastErr = respnose.GetException()
 		vlog.Warningf("FailOverHA call fail! url:%s, err:%+v\n", ep.GetURL().GetIdentity(), lastErr)
 	}
-	return getErrorResponse(request.GetRequestID(), fmt.Sprintf("call fail over %d times.Exception:%s", retries, lastErr.ErrMsg))
+	return getErrorResponse(request.GetRequestID(), fmt.Sprintf("FailOverHA call fail %d times.Exception:%s", retries+1, lastErr.ErrMsg))
 
 }
 

--- a/registry/zkRegistry_test.go
+++ b/registry/zkRegistry_test.go
@@ -1,1 +1,297 @@
 package registry
+
+import (
+	motan "github.com/weibocom/motan-go/core"
+	"testing"
+	"time"
+	"net"
+	"sync"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	//zk server url
+	zkURL           = &motan.URL{Host: "127.0.0.1", Port: 2181}
+	DefaultWaitTime = 100 * time.Millisecond
+	//unified test url
+	testURL = &motan.URL{
+		Protocol:   "zookeeper",
+		Group:      "zkTestGroup",
+		Path:       "zkTestPath",
+		Host:       "127.0.0.1",
+		Port:       1234,
+		Parameters: map[string]string{motan.ApplicationKey: "zkTestApp"},
+	}
+	//serverPath = "/motan/zkTestGroup/zkTestPath/server/127.0.0.1:1234"
+	serverPath = zkRegistryNamespace + zkPathSeparator + testURL.Group + zkPathSeparator + testURL.Path + zkPathSeparator + zkNodeTypeServer + zkPathSeparator + testURL.Host + ":" + testURL.GetPortStr()
+	//unavailableServerPath = "/motan/zkTestGroup/zkTestPath/unavailableServer/127.0.0.1:1234"
+	unavailableServerPath = zkRegistryNamespace + zkPathSeparator + testURL.Group + zkPathSeparator + testURL.Path + zkPathSeparator + zkNodeTypeUnavailableServer + zkPathSeparator + testURL.Host + ":" + testURL.GetPortStr()
+	//agentPath = "/motan/agent/zkTestApp/node/127.0.0.1:1234"
+	agentPath = zkRegistryNamespace + zkPathSeparator + zkNodeTypeAgent + zkPathSeparator + testURL.GetParam(motan.ApplicationKey, "") + zkRegistryNode + zkPathSeparator + testURL.Host + ":" + testURL.GetPortStr()
+	//commandPath = "/motan/zkTestGroup/command"
+	commandPath = zkRegistryNamespace + zkPathSeparator + testURL.Group + zkRegistryCommand
+	//agentCommandPath = "/motan/agent/zkTestApp/command"
+	agentCommandPath = zkRegistryNamespace + zkPathSeparator + zkNodeTypeAgent + zkPathSeparator + testURL.GetParam(motan.ApplicationKey, "") + zkRegistryCommand
+	z                = &ZkRegistry{}
+	hasZKServer      = false
+	once             sync.Once
+)
+
+//Test path generation methods.
+func TestZkRegistryToPath(t *testing.T) {
+	//Test path create methods.
+	if p := toNodePath(testURL, zkNodeTypeServer); p != serverPath {
+		t.Error("toNodePath err. result:", p)
+	}
+	if p := toCommandPath(testURL); p != commandPath {
+		t.Error("toCommandPath err. result:", p)
+	}
+	if p := toAgentNodePath(testURL); p != agentPath {
+		t.Error("toAgentNodePath err. result:", p)
+	}
+	if p := toAgentCommandPath(testURL); p != agentCommandPath {
+		t.Error("toAgentCommandPath err. result:", p)
+	}
+
+	//Test SetURL method and GetURL method.
+	z.SetURL(testURL)
+	assert.Equal(t, z.GetURL(), testURL)
+
+	//Test GetName method.
+	assert.Equal(t, z.GetName(), "zookeeper")
+}
+
+func TestZkRegistryBasic(t *testing.T) {
+	if once.Do(initZK); hasZKServer {
+		//Test createNode method: server path.
+		z.createNode(testURL, zkNodeTypeServer)
+		time.Sleep(DefaultWaitTime)
+		isExist, _, err := z.zkConn.Exists(serverPath)
+		if err != nil || !isExist {
+			t.Error("Create server node fail. exist:", isExist, " err:", err)
+		}
+
+		//Test createNode method: agent path.
+		z.createNode(testURL, zkNodeTypeAgent)
+		time.Sleep(DefaultWaitTime)
+		isExist, _, err = z.zkConn.Exists(agentPath)
+		if err != nil || !isExist {
+			t.Error("Create agent node fail. exist:", isExist, " err:", err)
+		}
+
+		//Test Discover method.
+		testURL.ClearCachedInfo()
+		disURL := z.Discover(testURL)
+		time.Sleep(DefaultWaitTime)
+		assert.Equal(t, disURL[0], testURL)
+
+		//Test DiscoverCommand method.
+		z.createPersistent(commandPath, true)
+		commandReq := "hello"
+		z.zkConn.Set(commandPath, []byte(commandReq), -1)
+		commandRes := z.DiscoverCommand(testURL)
+		time.Sleep(DefaultWaitTime)
+		assert.Equal(t, commandReq, commandRes)
+
+		//Test DiscoverCommand method.
+		z.createPersistent(agentCommandPath, true)
+		z.zkConn.Set(agentCommandPath, []byte(commandReq), -1)
+		testURL.PutParam("nodeType", zkNodeTypeAgent)
+		commandRes = z.DiscoverCommand(testURL)
+		testURL.PutParam("nodeType", "")
+		time.Sleep(DefaultWaitTime)
+		assert.Equal(t, commandReq, commandRes)
+
+		//Test removeNode method.
+		z.removeNode(testURL, zkNodeTypeServer)
+		time.Sleep(DefaultWaitTime)
+		if isExist, _, err := z.zkConn.Exists(serverPath); err == nil {
+			if isExist {
+				t.Error("removeNode fail.")
+			}
+		} else {
+			t.Error("removeNode err:", err)
+		}
+	}
+}
+
+func TestZkRegistryRegister(t *testing.T) {
+	if once.Do(initZK); hasZKServer {
+		//Test Available method: with parameter.
+		z.Register(testURL)
+		z.Available(testURL)
+		time.Sleep(DefaultWaitTime)
+		if isExist, _, err := z.zkConn.Exists(serverPath); err == nil {
+			if !isExist {
+				t.Error("Register fail.")
+			}
+		} else {
+			t.Error("Register err:", err)
+		}
+
+		//Test Unavailable method: without parameter.
+		z.Unavailable(testURL)
+		time.Sleep(DefaultWaitTime)
+		isExistUnAvail, _, errUnAvail := z.zkConn.Exists(unavailableServerPath)
+		isExistAvail, _, errAvail := z.zkConn.Exists(serverPath)
+		if errUnAvail == nil && errAvail == nil {
+			if !isExistUnAvail || isExistAvail {
+				t.Error("Unavailable fail.")
+			}
+		} else {
+			t.Error("Unavailable err:", errUnAvail, errAvail)
+		}
+
+		//Test Available method: without parameter.
+		z.Register(testURL)
+		z.Available(nil)
+		time.Sleep(DefaultWaitTime)
+		if isExist, _, err := z.zkConn.Exists(serverPath); err == nil {
+			if !isExist {
+				t.Error("Register fail.")
+			}
+		} else {
+			t.Error("Register err:", err)
+		}
+
+		//Test Unavailable method: with parameter.
+		z.Unavailable(nil)
+		time.Sleep(DefaultWaitTime)
+		isExistUnAvail, _, errUnAvail = z.zkConn.Exists(unavailableServerPath)
+		isExistAvail, _, errAvail = z.zkConn.Exists(serverPath)
+		if errUnAvail == nil && errAvail == nil {
+			if !isExistUnAvail || isExistAvail {
+				t.Error("Unavailable fail.")
+			}
+		} else {
+			t.Error("Unavailable err:", errUnAvail, errAvail)
+		}
+	}
+}
+
+func TestZkRegistrySubscribe(t *testing.T) {
+	if once.Do(initZK); hasZKServer {
+		//Test Register method.
+		z.Register(testURL)
+		time.Sleep(DefaultWaitTime)
+		if isExist, _, err := z.zkConn.Exists(unavailableServerPath); !isExist || err != nil {
+			t.Error("Register fail:", err)
+		}
+		testURL.PutParam("nodeType", zkNodeTypeAgent)
+		testURL.Group = "agent" //build different urlID
+		testURL.ClearCachedInfo()
+		z.Register(testURL)
+		testURL.Group = "zkTestGroup" //revert urlID
+		testURL.ClearCachedInfo()
+		if isExist, _, err := z.zkConn.Exists(agentPath); !isExist || err != nil {
+			t.Error("Register fail:", err)
+		}
+		testURL.PutParam("nodeType", "")
+
+		//Test GetRegisteredServices method.
+		assert.Equal(t, z.GetRegisteredServices()[0], testURL)
+
+		//Test Subscribe method.
+		lis := MockListener{registryURL: &motan.URL{}}
+		z.Subscribe(testURL, &lis)
+		z.createNode(testURL, zkNodeTypeServer)
+		time.Sleep(DefaultWaitTime)
+		urlRes := &motan.URL{
+			Host: zkURL.Host,
+			Port: zkURL.Port,
+		}
+		lis.registryURL.ClearCachedInfo()
+		time.Sleep(DefaultWaitTime)
+		assert.Equal(t, urlRes, lis.registryURL)
+
+		//Test UnSubscribe method.
+		lis = MockListener{}
+		z.Unsubscribe(testURL, &lis)
+		time.Sleep(DefaultWaitTime)
+		if listeners, ok := z.subscribedServiceMap[serverPath]; ok {
+			if _, ok := listeners[&lis]; ok {
+				t.Error("UnSubscribe fail. registryURL:", lis.registryURL)
+			}
+		}
+
+		//Test SubscribeCommand method: service command path.
+		lis = MockListener{}
+		z.createPersistent(commandPath, true)
+		z.SubscribeCommand(testURL, &lis)
+		commandReq := "hello"
+		z.zkConn.Set(commandPath, []byte(commandReq), -1)
+		time.Sleep(DefaultWaitTime)
+		//assert.Equal(t, commandReq, lis.command)
+
+		//Test SubscribeCommand method: agent command path.
+		lis = MockListener{}
+		testURL.PutParam("nodeType", zkNodeTypeAgent)
+		testURL.Group = "agentCommand" //build different urlID
+		testURL.ClearCachedInfo()
+		z.createPersistent(agentCommandPath, true)
+		z.SubscribeCommand(testURL, &lis)
+		testURL.Group = "zkTestGroup" //revert urlID
+		testURL.ClearCachedInfo()
+		testURL.PutParam("nodeType", "")
+		z.zkConn.Set(agentCommandPath, []byte(commandReq), -1)
+		time.Sleep(DefaultWaitTime)
+		assert.Equal(t, commandReq, lis.command)
+
+		//Test UnSubscribeCommand method: service command path.
+		z.UnSubscribeCommand(testURL, &lis)
+		time.Sleep(DefaultWaitTime)
+		if _, ok := z.switcherMap[commandPath]; ok {
+			t.Error("UnSubscribe command fail.")
+		}
+
+		//Test UnSubscribeCommand method: agent command path.
+		testURL.PutParam("nodeType", zkNodeTypeAgent)
+		z.UnSubscribeCommand(testURL, &lis)
+		testURL.PutParam("nodeType", "")
+		time.Sleep(DefaultWaitTime)
+		if _, ok := z.switcherMap[commandPath]; ok {
+			t.Error("UnSubscribe command fail.")
+		}
+
+		//Test UnRegister method.
+		z.UnRegister(testURL)
+		isExistUnReg, _, errUnReg := z.zkConn.Exists(unavailableServerPath)
+		isExistGeg, _, errReg := z.zkConn.Exists(serverPath)
+		if errUnReg == nil && errReg == nil {
+			if isExistUnReg || isExistGeg {
+				t.Error("UnRegister fail.")
+			}
+		} else {
+			t.Error("UnRegister err:", errUnReg, errReg)
+		}
+	}
+}
+
+func initZK() {
+	tcpAddr, _ := net.ResolveTCPAddr("tcp4", zkURL.GetAddressStr())
+	if _, err := net.DialTCP("tcp", nil, tcpAddr); err == nil {
+		z = &ZkRegistry{url: zkURL}
+		z.Initialize()
+		hasZKServer = true
+	}
+}
+
+type MockListener struct {
+	registryURL *motan.URL
+	urls        []*motan.URL
+	command     string
+}
+
+func (m *MockListener) Notify(registryURL *motan.URL, urls []*motan.URL) {
+	m.registryURL = registryURL
+	m.urls = urls
+}
+
+func (m *MockListener) NotifyCommand(registryURL *motan.URL, commandType int, commandInfo string) {
+	m.registryURL = registryURL
+	m.command = commandInfo
+}
+
+func (m *MockListener) GetIdentity() string {
+	return "mocklistener"
+}


### PR DESCRIPTION
Continue to refactor ZkRegistry for #60 and made some optimizations:
- Refactor `ZkRegistry`  with a complete unit test to match the [motan-java](https://github.com/weibocom/motan).
  - Using a new way to serialize nodeInfo, and the [motan-java](https://github.com/weibocom/motan) is modified accordingly: [#732](https://github.com/weibocom/motan/pull/732)
- Add utility method `TrimSplit` with a unit test, that trims spaces while splitting the string into a list.
- Optimize an ErrorResponse in failover HA.