### PR TITLE
Fix config split

### DIFF
--- a/cluster/motanCluster.go
+++ b/cluster/motanCluster.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	motan "github.com/weibocom/motan-go/core"
@@ -234,7 +233,7 @@ func (m *MotanCluster) parseRegistry() (err error) {
 		err = errors.New(errInfo)
 		vlog.Errorln(errInfo)
 	}
-	arr := strings.Split(regs, ",")
+	arr := motan.TrimSplit(regs, ",")
 	registries := make([]motan.Registry, 0, len(arr))
 	for _, r := range arr {
 		if registryURL, ok := m.Context.RegistryURLs[r]; ok {

--- a/core/url.go
+++ b/core/url.go
@@ -254,7 +254,7 @@ func GetURLFilters(url *URL, extFactory ExtentionFactory) (clusterFilter Cluster
 	if filters, ok := url.Parameters[FilterKey]; ok {
 		clusterFilters := make([]Filter, 0, 10)
 		endpointFilters = make([]Filter, 0, 10)
-		arr := strings.Split(filters, ",")
+		arr := TrimSplit(filters, ",")
 		for _, f := range arr {
 			filter := extFactory.GetFilter(f)
 			if filter != nil {

--- a/core/util.go
+++ b/core/util.go
@@ -22,7 +22,7 @@ const (
 func ParseExportInfo(export string) (string, int, error) {
 	port := defaultServerPort
 	protocol := defaultProtocal
-	s := strings.Split(export, ":")
+	s := TrimSplit(export, ":")
 	if len(s) == 1 && s[0] != "" {
 		port = s[0]
 	} else if len(s) == 2 {

--- a/provider/httpProvider.go
+++ b/provider/httpProvider.go
@@ -47,7 +47,7 @@ func (h *HTTPProvider) Initialize() {
 		for confID, info := range urlConf {
 			srvConf := make(srvConfT)
 			for methodArrStr, getSrvConf := range info.(map[interface{}]interface{}) {
-				methodArr := strings.Split(methodArrStr.(string), ",")
+				methodArr := motan.TrimSplit(methodArrStr.(string), ",")
 				for _, method := range methodArr {
 					sconf := make(sConfT)
 					for k, v := range getSrvConf.(map[interface{}]interface{}) {

--- a/registry/directRegistry.go
+++ b/registry/directRegistry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"strconv"
+	"strings"
 	motan "github.com/weibocom/motan-go/core"
 	"github.com/weibocom/motan-go/log"
 )
@@ -63,7 +64,7 @@ func parseURLs(url *motan.URL) []*motan.URL {
 	if len(url.Host) > 0 && url.Port > 0 {
 		urls = append(urls, url)
 	} else if address, exist := url.Parameters[motan.AddressKey]; exist {
-		for _, add := range motan.TrimSplit(address, ",") {
+		for _, add := range strings.Split(address, ",") {
 			hostport := motan.TrimSplit(add, ":")
 			if len(hostport) == 2 {
 				port, err := strconv.Atoi(hostport[1])

--- a/registry/directRegistry.go
+++ b/registry/directRegistry.go
@@ -2,8 +2,6 @@ package registry
 
 import (
 	"strconv"
-	"strings"
-
 	motan "github.com/weibocom/motan-go/core"
 	"github.com/weibocom/motan-go/log"
 )
@@ -65,8 +63,8 @@ func parseURLs(url *motan.URL) []*motan.URL {
 	if len(url.Host) > 0 && url.Port > 0 {
 		urls = append(urls, url)
 	} else if address, exist := url.Parameters[motan.AddressKey]; exist {
-		for _, add := range strings.Split(address, ",") {
-			hostport := strings.Split(add, ":")
+		for _, add := range motan.TrimSplit(address, ",") {
+			hostport := motan.TrimSplit(add, ":")
 			if len(hostport) == 2 {
 				port, err := strconv.Atoi(hostport[1])
 				if err == nil {

--- a/server.go
+++ b/server.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"sync"
 
 	motan "github.com/weibocom/motan-go/core"
@@ -92,7 +91,7 @@ func (m *MSContext) export(url *motan.URL) {
 		port := defaultServerPort
 		protocol := defaultProtocal
 		if export != "" {
-			s := strings.Split(export, ":")
+			s := motan.TrimSplit(export, ":")
 			if len(s) == 1 {
 				port = s[0]
 			} else if len(s) == 2 {

--- a/server/server.go
+++ b/server/server.go
@@ -3,8 +3,6 @@ package server
 import (
 	"errors"
 	"fmt"
-	"strings"
-
 	motan "github.com/weibocom/motan-go/core"
 	"github.com/weibocom/motan-go/log"
 )
@@ -59,7 +57,7 @@ func (d *DefaultExporter) Export(server motan.Server, extFactory motan.Extention
 		vlog.Errorln(errInfo)
 		return err
 	}
-	arr := strings.Split(regs, ",")
+	arr := motan.TrimSplit(regs, ",")
 	registries := make([]motan.Registry, 0, len(arr))
 	for _, r := range arr {
 		if registryURL, ok := context.RegistryURLs[r]; ok {


### PR DESCRIPTION
1. This fix is limited to the string split of the configuration file.
2. Contains split of the comma(`,`) and the colon(`:`) in `address`, `registry`, `filter`, `export` configuration items