### PR TITLE
Add global switcher && Optimize vlog

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -297,7 +297,7 @@ func (a *Agent) startServerAgent() {
 		}
 		motan.CanSetContext(provider, globalContext)
 		motan.Initialize(provider)
-		provider = mserver.WarperWithFilter(provider, a.extFactory)
+		provider = mserver.WrapWithFilter(provider, a.extFactory, globalContext)
 		exporter.SetProvider(provider)
 		server := a.agentPortServer[url.Port]
 		if server == nil {

--- a/agent.go
+++ b/agent.go
@@ -105,6 +105,7 @@ func (a *Agent) initParam() {
 		logdir = "."
 	}
 	initLog(logdir)
+	registerSwitchers(a.Context)
 
 	port := *motan.Port
 	if port == 0 && section != nil && section["port"] != nil {
@@ -231,7 +232,7 @@ func (a *Agent) registerAgent() {
 				}
 			}
 		} else {
-			vlog.Warningf("can not find agent registry in conf, so do not register. agent url:%s\n", a.agentURL)
+			vlog.Warningf("can not find agent registry in conf, so do not register. agent url:%s\n", a.agentURL.GetIdentity())
 		}
 	}
 }
@@ -371,6 +372,14 @@ func initLog(logdir string) {
 	flag.Set("log_dir", logdir)
 	vlog.FlushInterval = 1 * time.Second
 	vlog.LogInit(nil)
+}
+
+func registerSwitchers(c *motan.Context) {
+	switchers, _ := c.Config.GetSection(motan.SwitcherSection)
+	s := motan.GetSwitcherManager()
+	for n, v := range switchers {
+		s.Register(n.(string), v.(bool))
+	}
 }
 
 func getDefaultResponse(requestid uint64, errmsg string) *motan.MotanResponse {

--- a/agent.go
+++ b/agent.go
@@ -215,7 +215,7 @@ func (a *Agent) startAgent() {
 }
 
 func (a *Agent) registerAgent() {
-	vlog.Infoln("start agent regitstry.")
+	vlog.Infoln("start agent registry.")
 	if reg, exit := a.agentURL.Parameters[motan.RegistryKey]; exit {
 		if registryURL, regexit := a.Context.RegistryURLs[reg]; regexit {
 			registry := a.extFactory.GetRegistry(registryURL)
@@ -441,7 +441,7 @@ func (a *Agent) startMServer() {
 func (a *Agent) mhandle(k string, h http.Handler) {
 	defer func() {
 		if err := recover(); err != nil {
-			vlog.Warningf("managehandler register fail. maybe the pattern '%s' alreay regist\n", k)
+			vlog.Warningf("manageHandler register fail. maybe the pattern '%s' already registered\n", k)
 		}
 	}()
 	if sa, ok := h.(SetAgent); ok {

--- a/client.go
+++ b/client.go
@@ -111,6 +111,7 @@ func GetClientContext(confFile string) *MCContext {
 			logdir = "."
 		}
 		initLog(logdir)
+		registerSwitchers(mc.context)
 	}
 	return mc
 }

--- a/cluster/command_test.go
+++ b/cluster/command_test.go
@@ -27,12 +27,12 @@ func TestProcessRouter(t *testing.T) {
 
 	//not match
 	*motan.LocalIP = "10.75.0.8"
-	result := proceeRoute(urls, router)
+	result := processRoute(urls, router)
 	checksize(len(result), len(urls), t)
 
 	// prefix match
 	*motan.LocalIP = "10.73.1.8"
-	result = proceeRoute(urls, router)
+	result = processRoute(urls, router)
 	checksize(len(result), 2, t)
 	checkHost(result, func(host string) bool {
 		return !strings.HasPrefix(host, "10.75.1")
@@ -41,7 +41,7 @@ func TestProcessRouter(t *testing.T) {
 	// exact match
 	router = newRouter("10.75.0.8 to 10.73.1.*")
 	*motan.LocalIP = "10.75.0.8"
-	result = proceeRoute(urls, router)
+	result = processRoute(urls, router)
 	checksize(len(result), 2, t)
 	checkHost(result, func(host string) bool {
 		return !strings.HasPrefix(host, "10.73.1")
@@ -50,7 +50,7 @@ func TestProcessRouter(t *testing.T) {
 	// * match
 	router = newRouter(" * to 10.75.*")
 	*motan.LocalIP = "10.108.0.8"
-	result = proceeRoute(urls, router)
+	result = processRoute(urls, router)
 	checksize(len(result), 4, t)
 	checkHost(result, func(host string) bool {
 		return !strings.HasPrefix(host, "10.75")
@@ -59,18 +59,18 @@ func TestProcessRouter(t *testing.T) {
 	// multi rules
 	router = newRouter(" * to 10.75.*", "10.108.* to 10.77.1.* ")
 	*motan.LocalIP = "10.108.0.8"
-	result = proceeRoute(urls, router)
+	result = processRoute(urls, router)
 	checksize(len(result), 0, t)
 
 	router = newRouter(" * to 10.75.*", "10.108.* to 10.75.1.* ")
-	result = proceeRoute(urls, router)
+	result = processRoute(urls, router)
 	checksize(len(result), 2, t)
 	checkHost(result, func(host string) bool {
 		return !(strings.HasPrefix(host, "10.77.1") || strings.HasPrefix(host, "10.75"))
 	}, t)
 
 	router = newRouter(" * to 10.*", "10.108.* to !10.73.1.* ")
-	result = proceeRoute(urls, router)
+	result = processRoute(urls, router)
 	checksize(len(result), 6, t)
 	checkHost(result, func(host string) bool {
 		return !(strings.HasPrefix(host, "10.77.1") || strings.HasPrefix(host, "10.75"))
@@ -78,14 +78,14 @@ func TestProcessRouter(t *testing.T) {
 
 	router = newRouter(" 10.79.* to !10.75.1.*", "10.108.* to 10.73.1.* ", "10.108.* to !10.73.1.5")
 	*motan.LocalIP = "10.79.0.8"
-	result = proceeRoute(urls, router)
+	result = processRoute(urls, router)
 	checksize(len(result), 6, t)
 	checkHost(result, func(host string) bool {
 		return strings.HasPrefix(host, "10.75.1")
 	}, t)
 
 	*motan.LocalIP = "10.108.0.8"
-	result = proceeRoute(urls, router)
+	result = processRoute(urls, router)
 	checksize(len(result), 1, t)
 	checkHost(result, func(host string) bool {
 		return host != "10.73.1.3"
@@ -186,7 +186,7 @@ func TestProcessCommand(t *testing.T) {
 	fmt.Printf("notify:%t, crw:%+v\n", notify, crw)
 }
 
-func processServiceCmd(crw *CommandRegistryWarper, cl string, t *testing.T) {
+func processServiceCmd(crw *CommandRegistryWrapper, cl string, t *testing.T) {
 	notify := crw.processCommand(ServiceCmd, cl)
 	if crw.serviceCommandInfo != cl {
 		t.Errorf("serviceCommandInfo not correct! real:%s, expect:%s\n", crw.serviceCommandInfo, cl)
@@ -275,11 +275,11 @@ func checkHost(urls []*motan.URL, f func(host string) bool, t *testing.T) {
 	}
 }
 
-func getDefalultCommandWarper() *CommandRegistryWarper {
+func getDefalultCommandWarper() *CommandRegistryWrapper {
 	cluster := initCluster()
 	cluster.InitCluster()
 	registry := cluster.extFactory.GetRegistry(RegistryURL)
-	return GetCommandRegistryWarper(cluster, registry).(*CommandRegistryWarper)
+	return GetCommandRegistryWrapper(cluster, registry).(*CommandRegistryWrapper)
 }
 
 func buildCmd(index int, cmdType int, pattern string, mergeGroup string, routers string) string {

--- a/cluster/motanCluster.go
+++ b/cluster/motanCluster.go
@@ -242,7 +242,7 @@ func (m *MotanCluster) parseRegistry() (err error) {
 			registry := m.extFactory.GetRegistry(registryURL)
 			if registry != nil {
 				if _, ok := registry.(motan.DiscoverCommand); ok {
-					registry = GetCommandRegistryWarper(m, registry)
+					registry = GetCommandRegistryWrapper(m, registry)
 				}
 				registry.Subscribe(m.url, m)
 				registries = append(registries, registry)

--- a/core/globalContext.go
+++ b/core/globalContext.go
@@ -21,6 +21,7 @@ const (
 	serverSection        = "motan-server"
 	importSection        = "import-refer"
 	dynamicSection       = "dynamic-param"
+	SwitcherSection      = "switcher"
 
 	// URLConfKey is config id
 	// config Keys

--- a/core/switcher.go
+++ b/core/switcher.go
@@ -35,7 +35,9 @@ func (s *SwitcherManager) Register(name string, value bool, listeners ...Switche
 		return
 	}
 	newSwitcher := &Switcher{name: name, value: value, listeners: []SwitcherListener{}}
-	newSwitcher.Watch(listeners...)
+	if len(listeners) > 0 {
+		newSwitcher.Watch(listeners...)
+	}
 	s.switcherMap[name] = newSwitcher
 	vlog.Infof("[switcher] register %s success, value:%v, len(listeners):%d\n", name, value, len(listeners))
 }

--- a/core/switcher_test.go
+++ b/core/switcher_test.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+var (
+	notifyA  = false
+	notifyB  = false
+	notifyBB = false
+
+	lisA  = &switcherA{}
+	lisB  = &switcherB{}
+	lisBB = &switcherBB{}
+)
+
+type switcherA struct{}
+
+func (*switcherA) Notify(value bool) {
+	notifyA = true
+}
+
+type switcherB struct{}
+
+func (*switcherB) Notify(value bool) {
+	notifyB = true
+}
+
+type switcherBB struct{}
+
+func (*switcherBB) Notify(value bool) {
+	notifyBB = true
+}
+
+func TestSwitcher(t *testing.T) {
+	s := GetSwitcherManager()
+	if s == nil {
+		t.Error("GetSwitcherManager fail")
+	}
+
+	s.Register("aaa", true)
+	s.Register("bbb", true, lisB)
+	if switcherA := s.GetSwitcher("aaa"); switcherA != nil {
+		if switcherA.GetName() != "aaa" {
+			t.Error("GetName error, origin: aaa, return:", switcherA.GetName())
+		}
+	} else {
+		t.Error("GetSwitcher failed")
+	}
+
+	if check := s.GetSwitcher("aaa").IsOpen(); check != true {
+		t.Error("check IsOpen failed")
+	}
+
+	s.GetSwitcher("aaa").Watch(lisA)
+	s.GetSwitcher("bbb").Watch(lisBB)
+	s.GetSwitcher("aaa").SetValue(false)
+	s.GetSwitcher("bbb").SetValue(false)
+	time.Sleep(200 * time.Millisecond) //wait notify
+	if notifyA != true || notifyB != true || notifyBB != true {
+		t.Error("watch failed")
+	}
+
+	if switchers := s.GetAllSwitchers(); len(switchers) != 2 {
+		t.Error("GetAllSwitchers error. expect: 3, return:", len(switchers))
+	}
+}

--- a/default.go
+++ b/default.go
@@ -4,14 +4,14 @@ import (
 	"sync"
 
 	motan "github.com/weibocom/motan-go/core"
-	endpoint "github.com/weibocom/motan-go/endpoint"
-	filter "github.com/weibocom/motan-go/filter"
-	ha "github.com/weibocom/motan-go/ha"
-	lb "github.com/weibocom/motan-go/lb"
-	provider "github.com/weibocom/motan-go/provider"
-	registry "github.com/weibocom/motan-go/registry"
-	serialize "github.com/weibocom/motan-go/serialize"
-	server "github.com/weibocom/motan-go/server"
+	"github.com/weibocom/motan-go/endpoint"
+	"github.com/weibocom/motan-go/filter"
+	"github.com/weibocom/motan-go/ha"
+	"github.com/weibocom/motan-go/lb"
+	"github.com/weibocom/motan-go/provider"
+	"github.com/weibocom/motan-go/registry"
+	"github.com/weibocom/motan-go/serialize"
+	"github.com/weibocom/motan-go/server"
 	"net/http"
 )
 
@@ -34,14 +34,17 @@ func NoPermissionCheck(r *http.Request) bool {
 func GetDefaultManageHandlers() map[string]http.Handler {
 	handlerOnce.Do(func() {
 		defaultManageHandlers = make(map[string]http.Handler, 16)
+
 		status := &StatusHandler{}
 		defaultManageHandlers["/"] = status
 		defaultManageHandlers["/200"] = status
 		defaultManageHandlers["/503"] = status
 		defaultManageHandlers["/version"] = status
+
 		info := &InfoHandler{}
 		defaultManageHandlers["/getConfig"] = info
 		defaultManageHandlers["/getReferService"] = info
+
 		debug := &DebugHandler{}
 		defaultManageHandlers["/debug/pprof/"] = debug
 		defaultManageHandlers["/debug/pprof/cmdline"] = debug
@@ -50,6 +53,11 @@ func GetDefaultManageHandlers() map[string]http.Handler {
 		defaultManageHandlers["/debug/pprof/trace"] = debug
 		defaultManageHandlers["/debug/mesh/trace"] = debug
 		defaultManageHandlers["/debug/pprof/sw"] = debug
+
+		switcher := &SwitcherHandle{}
+		defaultManageHandlers["/switcher/set"] = switcher
+		defaultManageHandlers["/switcher/get"] = switcher
+		defaultManageHandlers["/switcher/getAll"] = switcher
 	})
 	return defaultManageHandlers
 }

--- a/log/invoker.go
+++ b/log/invoker.go
@@ -1,50 +1,68 @@
 package vlog
 
+import goLog "log"
+
 func Infoln(args ...interface{}) {
 	if log != nil {
 		log.Infoln(args...)
+	} else {
+		goLog.Println(args...)
 	}
 }
 
 func Infof(format string, args ...interface{}) {
 	if log != nil {
 		log.Infof(format, args...)
+	} else {
+		goLog.Printf(format, args...)
 	}
 }
 
 func Warningln(args ...interface{}) {
 	if log != nil {
 		log.Warningln(args...)
+	} else {
+		goLog.Println(args...)
 	}
 }
 
 func Warningf(format string, args ...interface{}) {
 	if log != nil {
 		log.Warningf(format, args...)
+	} else {
+		goLog.Printf(format, args...)
 	}
 }
 
 func Errorln(args ...interface{}) {
 	if log != nil {
 		log.Errorln(args...)
+	} else {
+		goLog.Println(args...)
 	}
 }
 
 func Errorf(format string, args ...interface{}) {
 	if log != nil {
 		log.Errorf(format, args...)
+	} else {
+		goLog.Printf(format, args...)
 	}
 }
 
 func Fatalln(args ...interface{}) {
 	if log != nil {
 		log.Fatalln(args...)
+	} else {
+		goLog.Println(args...)
 	}
 }
 
 func Fatalf(format string, args ...interface{}) {
 	if log != nil {
 		log.Fatalf(format, args...)
+	} else {
+		goLog.Printf(format, args...)
 	}
 }
 

--- a/metrics/graphite.go
+++ b/metrics/graphite.go
@@ -46,7 +46,7 @@ func (g *graphite) Write(snap metrics.Registry) error {
 	for _, message := range messages {
 		_, err = conn.Write([]byte(message))
 		if err != nil {
-			vlog.Errorln("graphite send message error: %v", err)
+			vlog.Errorf("graphite send message error: %v\n", err)
 		}
 	}
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -154,7 +154,7 @@ func (r *reporter) sink() {
 
 	for name, writer := range r.writers {
 		if err := writer.Write(snap); err != nil {
-			vlog.Errorln("metrics writer %s error : %v", name, err)
+			vlog.Errorf("metrics writer %s error : %v\n", name, err)
 			break
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -116,7 +116,7 @@ func (m *MSContext) export(url *motan.URL) {
 		provider := GetDefaultExtFactory().GetProvider(url)
 		provider.SetService(service)
 		motan.Initialize(provider)
-		provider = mserver.WarperWithFilter(provider, m.extFactory)
+		provider = mserver.WrapWithFilter(provider, m.extFactory, m.context)
 
 		exporter := &mserver.DefaultExporter{}
 		exporter.SetProvider(provider)

--- a/server.go
+++ b/server.go
@@ -65,6 +65,7 @@ func GetMotanServerContext(confFile string) *MSContext {
 			logdir = "."
 		}
 		initLog(logdir)
+		registerSwitchers(ms.context)
 	}
 	return ms
 }

--- a/server/server.go
+++ b/server/server.go
@@ -173,12 +173,13 @@ func (f *FilterProviderWarper) Call(request motan.Request) (res motan.Response) 
 	return f.filter.Filter(f.provider, request)
 }
 
-func WarperWithFilter(provider motan.Provider, extFactory motan.ExtentionFactory) motan.Provider {
+func WrapWithFilter(provider motan.Provider, extFactory motan.ExtentionFactory, context *motan.Context) motan.Provider {
 	var lastf motan.EndPointFilter
 	lastf = motan.GetLastEndPointFilter()
 	_, filters := motan.GetURLFilters(provider.GetURL(), extFactory)
 	for _, f := range filters {
 		if ef, ok := f.NewFilter(provider.GetURL()).(motan.EndPointFilter); ok {
+			motan.CanSetContext(ef, context)
 			ef.SetNext(lastf)
 			lastf = ef
 		}


### PR DESCRIPTION
1. The switcher can be registered in the configuration file:
```
switcher:
  aaa: true
  bbb: false
  ccc: true
```
2. The switcher can be set and get through manage port(default 8002), for examples:
  - set switcher `bbb`'s value `false`:      
```
localhost:8002/switcher/set?name=bbb&value=false
```
  - get switcher `bbb`'s value:    
```
localhost:8002/switcher/get?name=bbb
```
  - get all switchers value:     
```
localhost:8002/switcher/getAll
```
3. The switch can be called by user code. For a specific call example, see the switcher_test.go file.