### PR TITLE
Support pb array in pb serialization & Complete 2 missing error logs

### DIFF
--- a/endpoint/motanEndpoint.go
+++ b/endpoint/motanEndpoint.go
@@ -162,7 +162,9 @@ func (m *MotanEndpoint) Call(request motan.Request) motan.Response {
 		// reset errorCount
 		m.resetErr()
 	}
-	response.ProcessDeserializable(rc.Reply)
+	if err = response.ProcessDeserializable(rc.Reply); err != nil {
+		return m.defaultErrMotanResponse(request, err.Error())
+	}
 	response.SetProcessTime(int64((time.Now().UnixNano() - startTime) / 1000000))
 	return response
 }
@@ -355,7 +357,9 @@ func (s *Stream) notify(msg *mpro.Message, t time.Time) {
 				result.Done <- result
 				return
 			}
-			response.ProcessDeserializable(result.Reply)
+			if err = response.ProcessDeserializable(result.Reply); err != nil {
+				result.Error = err
+			}
 			response.SetProcessTime(int64((time.Now().UnixNano() - result.StartTime) / 1000000))
 			if s.rc.Tc != nil {
 				s.rc.Tc.PutResSpan(&motan.Span{Name: motan.Convert, Addr: s.channel.address, Time: time.Now()})

--- a/serialize/pb.go
+++ b/serialize/pb.go
@@ -2,6 +2,7 @@ package serialize
 
 import (
 	"errors"
+	"io"
 	"math"
 	"reflect"
 
@@ -142,13 +143,24 @@ func (p *PbSerialization) serializeBuf(buf *proto.Buffer, v interface{}) (err er
 		return buf.EncodeStringBytes(rv.String())
 	case reflect.Uint8:
 		return buf.EncodeVarint(rv.Uint())
+	case reflect.Slice: //  Experimental: This type only works in golang
+		for i := 0; i < rv.Len(); i++ {
+			iv := rv.Index(i)
+			if _, ok := iv.Interface().(proto.Message); !ok {
+				return errors.New("not support other types in pb-array in PbSerialization. type: " + iv.Elem().Kind().String())
+			}
+			if err = p.serializeBuf(buf, iv.Elem().Interface()); err != nil {
+				return err
+			}
+		}
+		return nil
 	default:
 		if rv.CanAddr() {
 			if pb, ok := rv.Addr().Interface().(proto.Message); ok {
 				return buf.EncodeMessage(pb)
 			}
 		}
-		return errors.New("not support serialize type in PbSerialization Serialize. type: " + rv.Type().String())
+		return errors.New("not support serialize type in PbSerialization. type: " + rv.Type().String())
 	}
 }
 
@@ -263,6 +275,23 @@ func (p *PbSerialization) deSerializeBuf(buf *proto.Buffer, v interface{}) (inte
 			*sv = uint8(dv)
 		}
 		return uint8(dv), err
+	case reflect.Slice: // Experimental: This type only works in golang
+		msgArray := reflect.ValueOf(v).Elem()
+		rtElem := rt.Elem()
+		if rtElem.Kind() != reflect.Ptr {
+			return nil, errors.New("not support non-pointer deserialize type in pb-array in PbSerialization. type: " + rtElem.String())
+		}
+		message := reflect.New(rtElem.Elem()).Interface()
+		for {
+			if _, err = p.deSerializeBuf(buf, message); err != nil {
+				if err == io.ErrUnexpectedEOF {
+					break
+				}
+				return nil, err
+			}
+			msgArray.Set(reflect.Append(msgArray, reflect.ValueOf(message)))
+		}
+		return msgArray, nil
 	default:
 		message, ok := v.(proto.Message)
 		if !ok {


### PR DESCRIPTION
1. This type only works in Golang's return type.
2. Completing 2 missing error logs