### PR TITLE
[http] Fix duplicate http header

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -496,8 +496,6 @@ func (a *agentMessageHandler) httpCall(request motan.Request, ck string, httpClu
 	httpResponse := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseRequest(httpRequest)
 	defer fasthttp.ReleaseResponse(httpResponse)
-	httpRequest.Header.DisableNormalizing()
-	httpResponse.Header.DisableNormalizing()
 	httpRequest.Header.Del("Host")
 	httpRequest.SetHost(originalService)
 	httpRequest.URI().SetPath(request.GetMethod())

--- a/provider/httpProvider.go
+++ b/provider/httpProvider.go
@@ -245,8 +245,6 @@ func (h *HTTPProvider) Call(request motan.Request) motan.Response {
 		}
 		httpReq := fasthttp.AcquireRequest()
 		httpRes := fasthttp.AcquireResponse()
-		httpReq.Header.DisableNormalizing()
-		httpRes.Header.DisableNormalizing()
 		defer fasthttp.ReleaseRequest(httpReq)
 		defer fasthttp.ReleaseResponse(httpRes)
 		httpReq.Header.Read(bufio.NewReader(bytes.NewReader(headerBytes)))
@@ -287,8 +285,6 @@ func (h *HTTPProvider) Call(request motan.Request) motan.Response {
 		}
 		httpReq := fasthttp.AcquireRequest()
 		httpRes := fasthttp.AcquireResponse()
-		httpReq.Header.DisableNormalizing()
-		httpRes.Header.DisableNormalizing()
 		defer fasthttp.ReleaseRequest(httpReq)
 		defer fasthttp.ReleaseResponse(httpRes)
 		err := mhttp.MotanRequestToFasthttpRequest(request, httpReq, h.defaultHTTPMethod)
@@ -300,7 +296,7 @@ func (h *HTTPProvider) Call(request motan.Request) motan.Response {
 		if len(httpReq.Header.Host()) == 0 {
 			httpReq.Header.SetHost(h.domain)
 		}
-		httpReq.Header.Add("X-Forwarded-For", ip)
+		httpReq.Header.Set("X-Forwarded-For", ip)
 		err = h.fastClient.Do(httpReq, httpRes)
 		if err != nil {
 			fillExceptionWithCode(resp, http.StatusServiceUnavailable, t, err)

--- a/server/httpProxyServer.go
+++ b/server/httpProxyServer.go
@@ -134,10 +134,9 @@ func (s *HTTPProxyServer) Open(block bool, proxy bool, clusterGetter HTTPCluster
 	}
 
 	s.httpServer = &fasthttp.Server{
-		Handler:                       s.httpHandler,
-		Name:                          HTTPProxyServerName,
-		NoDefaultServerHeader:         true,
-		DisableHeaderNamesNormalizing: true,
+		Handler:               s.httpHandler,
+		Name:                  HTTPProxyServerName,
+		NoDefaultServerHeader: true,
 	}
 	if block {
 		s.httpServer.ListenAndServe(s.url.Host + ":" + s.url.GetPortStr())


### PR DESCRIPTION
http mesh remove 'DisableNormalizing' option to avoid duplicate http header