### PR TITLE
[motanProtocol] Fix message clone

### DIFF
--- a/ha/backupRequestHA.go
+++ b/ha/backupRequestHA.go
@@ -54,6 +54,7 @@ func (br *BackupRequestHA) Call(request motan.Request, loadBalance motan.LoadBal
 	if retries == 0 {
 		return br.doCall(request, epList[0])
 	}
+	// TODO: we should use metrics of the cluster, with traffic control the group may changed
 	item := metrics.GetStatItem(metrics.Escape(request.GetAttachment(protocol.MGroup)), metrics.Escape(request.GetAttachment(protocol.MPath)))
 	if item == nil || item.LastSnapshot() == nil {
 		return br.doCall(request, epList[0])


### PR DESCRIPTION
Make sure Header.RequestID update will not result in memory leak. Now motan channel use Message.Header.RequestID as the cached request index, when response received motan channel will only remove the latest requestID indexed request, the previous requestID indexed requests still in the cached requests and will never be removed.