### PR TITLE
motanEndpoint & http proxy

### DIFF
--- a/endpoint/motanEndpoint.go
+++ b/endpoint/motanEndpoint.go
@@ -247,6 +247,7 @@ func (m *MotanEndpoint) keepalive() {
 				_, err = channel.Call(mpro.BuildHeartbeat(m.keepaliveID, mpro.Req), defaultRequestTimeout, nil)
 				if err == nil {
 					m.setAvailable(true)
+					m.resetErr()
 					vlog.Infof("[keepalive] heartbeat success. url: %s", m.url.GetIdentity())
 					return
 				}

--- a/http/httpProxy.go
+++ b/http/httpProxy.go
@@ -21,12 +21,13 @@ const (
 )
 
 const (
-	DomainKey           = "domain"
-	KeepaliveTimeoutKey = "keepaliveTimeout"
-	ProxyAddressKey     = "proxyAddress"
-	ProxySchemaKey      = "proxySchema"
-	MaxConnectionsKey   = "maxConnections"
-	EnableRewriteKey    = "enableRewrite"
+	DomainKey                = "domain"
+	KeepaliveTimeoutKey      = "keepaliveTimeout"
+	IdleConnectionTimeoutKey = "idleConnectionTimeout"
+	ProxyAddressKey          = "proxyAddress"
+	ProxySchemaKey           = "proxySchema"
+	MaxConnectionsKey        = "maxConnections"
+	EnableRewriteKey         = "enableRewrite"
 )
 
 const (

--- a/provider/httpProvider.go
+++ b/provider/httpProvider.go
@@ -56,7 +56,9 @@ const (
 // Initialize http provider
 func (h *HTTPProvider) Initialize() {
 	timeout := h.url.GetTimeDuration(motan.TimeOutKey, time.Millisecond, DefaultRequestTimeout)
-	keepaliveTimeout := h.url.GetTimeDuration(mhttp.KeepaliveTimeoutKey, time.Millisecond, 5*time.Second)
+	// http proxy connection keepalive duration, default 0 means unlimited
+	keepaliveTimeout := h.url.GetTimeDuration(mhttp.KeepaliveTimeoutKey, time.Millisecond, 0)
+	idleConnectionTimeout := h.url.GetTimeDuration(mhttp.IdleConnectionTimeoutKey, time.Millisecond, 5*time.Second)
 	h.srvURLMap = make(srvURLMapT)
 	urlConf, _ := h.gctx.Config.GetSection("http-service")
 	if urlConf != nil {
@@ -103,7 +105,8 @@ func (h *HTTPProvider) Initialize() {
 			}
 			return c, nil
 		},
-		MaxIdleConnDuration: keepaliveTimeout,
+		MaxConnDuration:     keepaliveTimeout,
+		MaxIdleConnDuration: idleConnectionTimeout,
 		MaxConns:            h.maxConnections,
 		ReadTimeout:         timeout,
 		WriteTimeout:        timeout,


### PR DESCRIPTION
[motanEndpoint] 
After keepalive successfully, reset error count.
  Prevent the following:
   The endpoint will be available but actually unavailable in case:
     Only the keepalive request is ok by some reason at one time, and other requests always failed.
[http] 
Fix timeout meaning
