### PR TITLE
httpprovider compatibility

### DIFF
--- a/core/url.go
+++ b/core/url.go
@@ -60,6 +60,16 @@ func (u *URL) GetIntValue(key string, defaultValue int64) int64 {
 	return defaultValue
 }
 
+func (u *URL) GetBoolValue(key string, defaultValue bool) bool {
+	if v, ok := u.Parameters[key]; ok {
+		boolValue, err := strconv.ParseBool(v)
+		if err == nil {
+			return boolValue
+		}
+	}
+	return defaultValue
+}
+
 func (u *URL) GetInt(key string) (int64, bool) {
 	if v, ok := u.Parameters[key]; ok {
 		intValue, err := strconv.ParseInt(v, 10, 64)

--- a/http/httpProxy.go
+++ b/http/httpProxy.go
@@ -28,6 +28,7 @@ const (
 	ProxySchemaKey           = "proxySchema"
 	MaxConnectionsKey        = "maxConnections"
 	EnableRewriteKey         = "enableRewrite"
+	EnableStringResponse     = "enableStringResponse"
 )
 
 const (


### PR DESCRIPTION
http provider support return string type result for rpc request, beacuase old usage result type is string, we need add the same ability for new usage