### PR TITLE
1. MotanCluster on refresh add: shuffle endpoints list avoid to call to determine server nodes when the list is not change. 2.MotanEndpoint ensure trigger keepalive in recordErrAndKeepalive.

### DIFF
--- a/cluster/motanCluster.go
+++ b/cluster/motanCluster.go
@@ -122,8 +122,15 @@ func (m *MotanCluster) refresh() {
 			newRefers = append(newRefers, e)
 		}
 	}
+	// shuffle endpoints list avoid to call to determine server nodes when the list is not change.
+	newRefers = m.ShuffleEndpoints(newRefers)
 	m.Refers = newRefers
 	m.LoadBalance.OnRefresh(newRefers)
+}
+func (m *MotanCluster) ShuffleEndpoints(endpoints []motan.EndPoint) []motan.EndPoint {
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(endpoints), func(i, j int) { endpoints[i], endpoints[j] = endpoints[j], endpoints[i] })
+	return endpoints
 }
 func (m *MotanCluster) AddRegistry(registry motan.Registry) {
 	m.Registries = append(m.Registries, registry)

--- a/endpoint/motanEndpoint.go
+++ b/endpoint/motanEndpoint.go
@@ -223,11 +223,7 @@ func (m *MotanEndpoint) recordErrAndKeepalive() {
 	if errCount >= uint32(m.errorCountThreshold) {
 		m.setAvailable(false)
 		vlog.Infoln("Referer disable:" + m.url.GetIdentity())
-		// Add if in go m.keepalive() to determine whether to go m.keepalive() according to the state.
-		// When the concurrency is high, it can filter out most unnecessary startups of a goroutine.
-		if !m.keepaliveRunning {
-			go m.keepalive()
-		}
+		go m.keepalive()
 	}
 }
 

--- a/provider/motanProvider.go
+++ b/provider/motanProvider.go
@@ -55,6 +55,8 @@ func (m *MotanProvider) Initialize() {
 
 func (m *MotanProvider) Call(request motan.Request) motan.Response {
 	if m.IsAvailable() {
+		// x-forwared-for
+		request.SetAttachment("x-forwarded-for", request.GetAttachment(motan.HostKey))
 		return m.ep.Call(request)
 	}
 	t := time.Now().UnixNano()


### PR DESCRIPTION
1. MotanCluster on refresh add: shuffle endpoints list avoid to call to determine server nodes when the list is not change.
2.MotanEndpoint ensure trigger keepalive in recordErrAndKeepalive.