### PR TITLE
fill motan v1 default request info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ main/magent*
 log/log.test*
 go.sum
 agent_runtime
+test/

--- a/agent_test.go
+++ b/agent_test.go
@@ -67,6 +67,7 @@ motan-refer:
       path: helloService
       protocol: motan2
       registry: direct
+      asyncInitConnection: false
       serialization: breeze`)))
 	agent := NewAgent(ext)
 	go agent.StartMotanAgentFromConfig(config)
@@ -110,6 +111,7 @@ motan-refer:
       protocol: motanV1Compatible
       registry: direct
       serialization: breeze
+      asyncInitConnection: false
 `)))
 	agent := NewAgent(ext)
 	go agent.StartMotanAgentFromConfig(config1)
@@ -132,6 +134,7 @@ motan-refer:
     group: hello
     path: helloService
     requestTimeout: 3000
+    asyncInitConnection: false
 `)))
 	mccontext := NewClientContextFromConfig(cfg)
 	mccontext.Start(ext1)
@@ -355,6 +358,7 @@ func TestAgent_InitCall(t *testing.T) {
 	agent.agentURL = &core.URL{Parameters: make(map[string]string)}
 	urlTest := &core.URL{Parameters: make(map[string]string)}
 	urlTest.Group = "test1"
+	urlTest.Parameters[core.AsyncInitConnection] = "false"
 	agent.initCluster(urlTest)
 	agentHandler := &agentMessageHandler{agent: agent}
 
@@ -494,6 +498,7 @@ func TestNotFoundProvider(t *testing.T) {
 			core.ApplicationKey:          "testep",
 			core.ConnectRetryIntervalKey: "5000",
 			core.ErrorCountThresholdKey:  "0",
+			core.AsyncInitConnection:     "false",
 		},
 	}
 	ext := GetDefaultExtFactory()

--- a/client_test.go
+++ b/client_test.go
@@ -28,6 +28,7 @@ motan-refer:
     protocol: motan2
     registry: direct
     serialization: simple
+    asyncInitConnection: false
 `
 	conf, err := config.NewConfigFromReader(bytes.NewReader([]byte(cfgText)))
 	assert.Nil(err)

--- a/cluster/motanCluster.go
+++ b/cluster/motanCluster.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	motan "github.com/weibocom/motan-go/core"
-	"github.com/weibocom/motan-go/endpoint"
 	"github.com/weibocom/motan-go/log"
-	"github.com/weibocom/motan-go/protocol"
 )
 
 type MotanCluster struct {
@@ -68,13 +66,6 @@ func (m *MotanCluster) Call(request motan.Request) (res motan.Response) {
 		vlog.Errorf("cluster call panic. req:%s", motan.GetReqInfo(request))
 	})
 	if m.available {
-		if m.proxy {
-			// TODO: for case client has no group or protocol convert
-			// we should have the same entry to set all necessary attachments
-			if endpoint.GetRequestGroup(request) == "" {
-				request.SetAttachment(protocol.MGroup, m.url.Group)
-			}
-		}
 		return m.clusterFilter.Filter(m.HaStrategy, m.LoadBalance, request)
 	}
 	vlog.Infoln("cluster:" + m.GetIdentity() + "is not available!")
@@ -234,7 +225,7 @@ func (m *MotanCluster) addFilter(ep motan.EndPoint, filters []motan.Filter) mota
 	}
 	fep.StatusFilters = statusFilters
 	fep.Filter = lastf
-	vlog.Infof("MotanCluster add ep filters. url:%+v, filters:%s", ep.GetURL(), motan.GetEPFilterInfo(fep.Filter))
+	vlog.Infof("MotanCluster add ep filters. url:%s, filters:%s", ep.GetURL().GetIdentity(), motan.GetEPFilterInfo(fep.Filter))
 	return fep
 }
 

--- a/core/motan.go
+++ b/core/motan.go
@@ -373,6 +373,9 @@ type RPCContext struct {
 
 	// trace context
 	Tc *TraceContext
+
+	// ----  internal vars ----
+	IsMotanV1 bool
 }
 
 func (c *RPCContext) AddFinishHandler(handler FinishHandler) {

--- a/core/switcher.go
+++ b/core/switcher.go
@@ -30,8 +30,7 @@ func (s *SwitcherManager) Register(name string, value bool, listeners ...Switche
 	}
 	s.switcherLock.Lock()
 	defer s.switcherLock.Unlock()
-	if _, ok := s.switcherMap[name]; ok {
-		vlog.Warningf("[switcher] register failed: %s has been registered", name)
+	if _, ok := s.switcherMap[name]; ok { // just ignore if already registered
 		return
 	}
 	newSwitcher := &Switcher{name: name, value: value, listeners: []SwitcherListener{}}

--- a/endpoint/motanCommonEndpoint_test.go
+++ b/endpoint/motanCommonEndpoint_test.go
@@ -15,6 +15,7 @@ import (
 func TestGetV1Name(t *testing.T) {
 	url := &motan.URL{Port: 8989, Protocol: "motanV1Compatible"}
 	url.PutParam(motan.TimeOutKey, "100")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanCommonEndpoint{}
 	ep.SetURL(url)
 
@@ -34,6 +35,7 @@ func TestV1RecordErrEmptyThreshold(t *testing.T) {
 	url := &motan.URL{Port: 8989, Protocol: "motanV1Compatible"}
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanCommonEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -54,6 +56,7 @@ func TestV1RecordErrWithErrThreshold(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ErrorCountThresholdKey, "5")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanCommonEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -85,6 +88,7 @@ func TestMotanCommonEndpoint_SuccessCall(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "2000")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanCommonEndpoint{}
 	ep.SetURL(url)
 	ep.SetSerialization(&serialize.SimpleSerialization{})
@@ -105,6 +109,7 @@ func TestMotanCommonEndpoint_AsyncCall(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "2000")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanCommonEndpoint{}
 	ep.SetURL(url)
 	ep.SetSerialization(&serialize.SimpleSerialization{})
@@ -125,6 +130,7 @@ func TestMotanCommonEndpoint_ErrorCall(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanCommonEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -149,6 +155,7 @@ func TestMotanCommonEndpoint_RequestTimeout(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanCommonEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -174,6 +181,7 @@ func TestV1LazyInit(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanCommonEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)

--- a/endpoint/motanEndpoint_test.go
+++ b/endpoint/motanEndpoint_test.go
@@ -25,6 +25,7 @@ func TestMain(m *testing.M) {
 func TestGetName(t *testing.T) {
 	url := &motan.URL{Port: 8989, Protocol: "motan2"}
 	url.PutParam(motan.TimeOutKey, "100")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -43,6 +44,7 @@ func TestRecordErrEmptyThreshold(t *testing.T) {
 	url := &motan.URL{Port: 8989, Protocol: "motan2"}
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -63,6 +65,7 @@ func TestRecordErrWithErrThreshold(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ErrorCountThresholdKey, "5")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -94,6 +97,7 @@ func TestMotanEndpoint_SuccessCall(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "2000")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanEndpoint{}
 	ep.SetURL(url)
 	ep.SetSerialization(&serialize.SimpleSerialization{})
@@ -115,6 +119,7 @@ func TestMotanEndpoint_AsyncCall(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "2000")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanEndpoint{}
 	ep.SetURL(url)
 	ep.SetSerialization(&serialize.SimpleSerialization{})
@@ -136,6 +141,7 @@ func TestMotanEndpoint_ErrorCall(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -160,6 +166,7 @@ func TestMotanEndpoint_RequestTimeout(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)
@@ -185,6 +192,7 @@ func TestLazyInit(t *testing.T) {
 	url.PutParam(motan.TimeOutKey, "100")
 	url.PutParam(motan.ErrorCountThresholdKey, "1")
 	url.PutParam(motan.ClientConnectionKey, "1")
+	url.PutParam(motan.AsyncInitConnection, "false")
 	ep := &MotanEndpoint{}
 	ep.SetURL(url)
 	ep.SetProxy(true)

--- a/http/httpRpc_test.go
+++ b/http/httpRpc_test.go
@@ -113,6 +113,7 @@ func callTimeOut(address string, port string, path string, group string, timeout
 	clientExt := motan.GetDefaultExtFactory()
 	info := fmt.Sprintf("motan2://%s:%s/%s?serialization=simple&maxRequestTimeout=30000&group=%s", address, port, path, group)
 	u := motancore.FromExtInfo(info)
+	u.PutParam(motancore.AsyncInitConnection, "false")
 	ep = clientExt.GetEndPoint(u)
 	if ep == nil {
 		return nil, fmt.Errorf("get end point error")
@@ -150,6 +151,7 @@ func callTimeOutWithAttachment(address string, port string, path string, group s
 	clientExt := motan.GetDefaultExtFactory()
 	info := fmt.Sprintf("motan2://%s:%s/%s?serialization=simple&maxRequestTimeout=30000&group=%s", address, port, path, group)
 	u := motancore.FromExtInfo(info)
+	u.PutParam(motancore.AsyncInitConnection, "false")
 	ep = clientExt.GetEndPoint(u)
 	if ep == nil {
 		return nil, fmt.Errorf("get end point error")
@@ -190,6 +192,7 @@ func callTimeOutWrongArgumentCount(address string, port string, path string, gro
 	clientExt := motan.GetDefaultExtFactory()
 	info := fmt.Sprintf("motan2://%s:%s/%s?serialization=simple&maxRequestTimeout=30000&group=%s", address, port, path, group)
 	u := motancore.FromExtInfo(info)
+	u.PutParam(motancore.AsyncInitConnection, "false")
 	ep = clientExt.GetEndPoint(u)
 	if ep == nil {
 		return nil, fmt.Errorf("get end point error")

--- a/meshClient.go
+++ b/meshClient.go
@@ -69,6 +69,7 @@ func (c *MeshClient) Initialize() {
 	clusterURL.PutParam(core.RegistryKey, meshDirectRegistryKey)
 	clusterURL.PutParam(core.ConnectRetryIntervalKey, "5000")
 	clusterURL.PutParam(core.SerializationKey, c.serialization)
+	clusterURL.PutParam(core.AsyncInitConnection, "false")
 	meshRegistryURL := &core.URL{}
 	meshRegistryURL.Protocol = "direct"
 	meshRegistryURL.PutParam(core.AddressKey, c.address)

--- a/protocol/motan1Protocol.go
+++ b/protocol/motan1Protocol.go
@@ -106,7 +106,9 @@ func DecodeMotanV1Request(msg *MotanV1Message) (motan.Request, error) {
 		Method:      objStream.method,
 		MethodDesc:  objStream.paramDesc,
 		Attachment:  objStream.attachment}
-	request.GetRPCContext(true).OriginalMessage = msg
+	ctx := request.GetRPCContext(true)
+	ctx.OriginalMessage = msg
+	ctx.IsMotanV1 = true
 	return request, nil
 }
 
@@ -138,7 +140,9 @@ func DecodeMotanV1Response(msg *MotanV1Message) (motan.Response, error) {
 			response.Exception = &motan.Exception{ErrCode: 500, ErrMsg: "v1: has exception, class:" + objStream.cName, ErrType: motan.ServiceException}
 		}
 	}
-	response.GetRPCContext(true).OriginalMessage = msg
+	ctx := response.GetRPCContext(true)
+	ctx.OriginalMessage = msg
+	ctx.IsMotanV1 = true
 	return response, nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -52,6 +52,7 @@ motan-server:
 	clientExt := GetDefaultExtFactory()
 	u := motan.FromExtInfo("motan2://127.0.0.1:64332/helloService?serialization=simple")
 	assert.NotNil(u)
+	u.Parameters["asyncInitConnection"] = "false"
 	ep := clientExt.GetEndPoint(u)
 	assert.NotNil(ep)
 	ep.SetSerialization(motan.GetSerialization(u, ext))
@@ -98,6 +99,7 @@ func TestNewMotanServerContextFromConfig(t *testing.T) {
 	ext := startServer(t, "helloService", 64532)
 	clientExt := GetDefaultExtFactory()
 	u := motan.FromExtInfo("motan2://127.0.0.1:64532/helloService?serialization=simple")
+	u.Parameters["asyncInitConnection"] = "false"
 	assert.NotNil(u)
 	ep := clientExt.GetEndPoint(u)
 	assert.NotNil(ep)

--- a/testdata/agent-reload.yaml
+++ b/testdata/agent-reload.yaml
@@ -15,6 +15,7 @@ motan-basicRefer:
     protocol: motan2
     registry: direct
     serialization: simple
+    asyncInitConnection: false
 
 #conf of refers
 motan-refer:


### PR DESCRIPTION
fill motan v1 default request info;
change endpoint channel init asynchronously；
narrow down the scope of initCluster locks;